### PR TITLE
fix: solana-test-validator macos error, expects gnu-tar (#22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,11 +149,22 @@ Error: failed to start validator: Failed to create ledger at test-ledger: io err
 ```
 
 This is because the BSD tar program is not compatible with the GNU tar program.
-To fix it: 
+
+FIX: install GNU tar program using homebrew and export it's executable path in your .zshrc file.
+
+## Mac with Apple Silicon
 
 ```bash
 brew install gnu-tar
 # Put this in ~/.zshrc 
 export PATH="/opt/homebrew/opt/gnu-tar/libexec/gnubin:$PATH"
 ```
-see https://solana.stackexchange.com/questions/4499/blockstore-error-when-starting-solana-test-validator-on-macos-13-0-1
+
+## Intel-based Mac
+
+```bash
+brew install gnu-tar
+# Put this in ~/.zshrc 
+export PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH"
+```
+see https://solana.stackexchange.com/questions/4499/blockstore-error-when-starting-solana-test-validator-on-macos-13-0-1/16319#16319


### PR DESCRIPTION
### This PR updates the troubleshooting part of the documentation regarding macOS error #22 

This is because the BSD tar program is not compatible with the GNU tar program.

To fix it: you need to install and export the executable path of your GNU tar program in your .zshrc file.

# Mac with Apple Silicon
```
brew install gnu-tar
# Put this in ~/.zshrc 
export PATH="/opt/homebrew/opt/gnu-tar/libexec/gnubin:$PATH"
```

# Intel-based Mac
```
brew install gnu-tar
# Put this in ~/.zshrc 
export PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH"
```

the only reason there are separate exports for intel-based macs and macs with apple silicon is that, by default, homebrew executables are stored at different locations for macs with respective chipset.