### PR TITLE
fix: add domain separator in the TSS message signature hash

### DIFF
--- a/programs/protocol-contracts-solana/src/lib.rs
+++ b/programs/protocol-contracts-solana/src/lib.rs
@@ -163,6 +163,7 @@ pub mod gateway {
             return err!(Errors::NonceMismatch);
         }
         let mut concatenated_buffer = Vec::new();
+        concatenated_buffer.extend_from_slice("withdraw".as_bytes());
         concatenated_buffer.extend_from_slice(&pda.chain_id.to_be_bytes());
         concatenated_buffer.extend_from_slice(&nonce.to_be_bytes());
         concatenated_buffer.extend_from_slice(&amount.to_be_bytes());
@@ -203,10 +204,13 @@ pub mod gateway {
             msg!("mismatch nonce");
             return err!(Errors::NonceMismatch);
         }
+
         let mut concatenated_buffer = Vec::new();
+        concatenated_buffer.extend_from_slice("withdraw_spl_token".as_bytes());
         concatenated_buffer.extend_from_slice(&pda.chain_id.to_be_bytes());
         concatenated_buffer.extend_from_slice(&nonce.to_be_bytes());
         concatenated_buffer.extend_from_slice(&amount.to_be_bytes());
+        concatenated_buffer.extend_from_slice(&ctx.accounts.from.key().to_bytes());
         concatenated_buffer.extend_from_slice(&ctx.accounts.to.key().to_bytes());
         require!(
             message_hash == hash(&concatenated_buffer[..]).to_bytes(),

--- a/programs/protocol-contracts-solana/src/lib.rs
+++ b/programs/protocol-contracts-solana/src/lib.rs
@@ -3,7 +3,6 @@ use anchor_lang::system_program;
 use anchor_spl::token::{transfer, Token, TokenAccount};
 use solana_program::keccak::hash;
 use solana_program::secp256k1_recover::secp256k1_recover;
-use spl_associated_token_account;
 use std::mem::size_of;
 
 #[error_code]

--- a/tests/protocol-contracts-solana.ts
+++ b/tests/protocol-contracts-solana.ts
@@ -184,9 +184,11 @@ describe("some tests", () => {
         const amount = new anchor.BN(500_000);
         const nonce = pdaAccountData.nonce;
         const buffer = Buffer.concat([
+            Buffer.from("withdraw_spl_token","utf-8"),
             chain_id_bn.toArrayLike(Buffer, 'be', 8),
             nonce.toArrayLike(Buffer, 'be', 8),
             amount.toArrayLike(Buffer, 'be', 8),
+            pda_ata.address.toBuffer(),
             wallet_ata.toBuffer(),
         ]);
         const message_hash = keccak256(buffer);
@@ -251,6 +253,7 @@ describe("some tests", () => {
         const amount = new anchor.BN(500000000);
         const to = wallet.publicKey;
         const buffer = Buffer.concat([
+            Buffer.from("withdraw","utf-8"),
             chain_id_bn.toArrayLike(Buffer, 'be', 8),
             nonce.toArrayLike(Buffer, 'be', 8),
             amount.toArrayLike(Buffer, 'be', 8),


### PR DESCRIPTION
This addresses potential issue that a TSS signed message can be used in either of the two withdraw functions. 