### PR TITLE
ci: added license, fix npm publish

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -15,36 +15,41 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install Node.js, Solana CLI and Anchor
+      - name: Install Node.js, Solana CLI, and Anchor
         uses: metadaoproject/setup-anchor@v2
-        with: 
-          anchor-version: '0.30.0' 
+        with:
+          anchor-version: '0.30.0'
           solana-cli-version: '1.18.15'
           node-version: '21.0.0'
+
+      - name: Setup Node.js for NPM Publish
+        uses: actions/setup-node@v4
+        with:
+          node-version: '21.0.0'
+          registry-url: 'https://registry.npmjs.org'
+          auth-token: ${{ secrets.NPM_TOKEN }}
 
       - name: Build
         run: anchor build
 
       - name: Prepare IDL Files
-        run: |
-          mv target/idl ./
+        run: mv target/idl ./
 
       - name: Determine NPM Tag
         id: determine-npm-tag
         run: |
-          VERSION_TAG=${GITHUB_REF#refs/tags/v}
+          VERSION_TAG=${{ github.ref_name }}
           if [[ $VERSION_TAG == *"-"* ]]; then
-            echo "NPM_TAG=${VERSION_TAG#*-}" >> "$GITHUB_ENV"
+            NPM_TAG=${VERSION_TAG#*-}
           else
-            echo "NPM_TAG=latest" >> "$GITHUB_ENV"
+            NPM_TAG=latest
           fi
-        env:
-          GITHUB_REF: ${{ github.ref }}
+          echo "NPM_TAG=$NPM_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Publish to NPM
         run: |
-          yarn publish --access public --new-version ${GITHUB_REF#refs/tags/v} --tag ${{
-          steps.determine-npm-tag.outputs.NPM_TAG }} --no-git-tag-version
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GITHUB_REF: ${{ github.ref }}
+          yarn publish \
+            --access public \
+            --new-version "${{ github.ref_name }}" \
+            --tag "${{ steps.determine-npm-tag.outputs.NPM_TAG }}" \
+            --no-git-tag-version

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Meta Protocol, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@zetachain/protocol-contracts-solana",
   "private": false,
+  "license": "MIT",
   "version": "0.0.0-set-on-publish",
   "description": "Package contains IDL files for the Solana Gateway program, enabling cross-chain functionality with ZetaChain",
   "files": [


### PR DESCRIPTION
Publishing on npm failed:

https://github.com/zeta-chain/protocol-contracts-solana/actions/runs/10958248436/job/30428068789

I think this is because `metaDAOproject/setup-anchor` doesn't specify the npm registry when setting up npm:

https://github.com/metaDAOproject/setup-anchor/blob/087a07cc86e8adcca657b9aaf0af9d5d4c504871/action.yml#L22-L24

And GH docs say one should do it:

> Please note that you need to set the registry-url to https://registry.npmjs.org/ in setup-node to properly configure your credentials.

Also, added a license.