### PR TITLE
refactor `deposit_and_call` and `deposit_spl_token_and_call` 

### DIFF
--- a/programs/protocol-contracts-solana/src/lib.rs
+++ b/programs/protocol-contracts-solana/src/lib.rs
@@ -122,7 +122,6 @@ pub mod gateway {
         amount: u64,
         receiver: [u8; 20],
     ) -> Result<()> {
-
         let token = &ctx.accounts.token_program;
         let from = &ctx.accounts.from;
 
@@ -153,7 +152,6 @@ pub mod gateway {
 
         Ok(())
     }
-
 
     pub fn deposit_spl_token_and_call(
         ctx: Context<DepositSplToken>,

--- a/programs/protocol-contracts-solana/src/lib.rs
+++ b/programs/protocol-contracts-solana/src/lib.rs
@@ -84,7 +84,11 @@ pub mod gateway {
         Ok(())
     }
 
-    pub fn deposit(ctx: Context<Deposit>, amount: u64, receiver: [u8; 20]) -> Result<()> {
+    pub fn deposit(
+        ctx: Context<Deposit>,
+        amount: u64,
+        receiver: [u8; 20], // not used in this program; for directing zetachain protocol only
+    ) -> Result<()> {
         let pda = &mut ctx.accounts.pda;
         require!(!pda.deposit_paused, Errors::DepositPaused);
 
@@ -114,13 +118,13 @@ pub mod gateway {
     ) -> Result<()> {
         require!(message.len() <= 512, Errors::MemoLengthExceeded);
         deposit(ctx, amount, receiver)?;
-        return Ok(());
+        Ok(())
     }
 
     pub fn deposit_spl_token(
         ctx: Context<DepositSplToken>,
         amount: u64,
-        receiver: [u8; 20],
+        receiver: [u8; 20], // unused in this program; for directing zetachain protocol only
     ) -> Result<()> {
         let token = &ctx.accounts.token_program;
         let from = &ctx.accounts.from;
@@ -161,7 +165,7 @@ pub mod gateway {
     ) -> Result<()> {
         require!(message.len() <= 512, Errors::MemoLengthExceeded);
         deposit_spl_token(ctx, amount, receiver)?;
-        return Ok(());
+        Ok(())
     }
 
     // require tss address signature on the internal message defined in the following

--- a/programs/protocol-contracts-solana/src/lib.rs
+++ b/programs/protocol-contracts-solana/src/lib.rs
@@ -134,6 +134,7 @@ pub mod gateway {
     // will get corresponding ZRC20 credit.
     // amount: amount of SPL token to deposit
     // receiver: ethereum address (20Bytes) of the receiver on ZetaChain zEVM
+    #[allow(unused)]
     pub fn deposit_spl_token(
         ctx: Context<DepositSplToken>,
         amount: u64,
@@ -175,6 +176,7 @@ pub mod gateway {
     // will get corresponding ZRC20 credit. The `receiver` should be a contract
     // on zEVM and the `message` will be used as input data for the contract call.
     // The `receiver` contract on zEVM will get the SPL token ZRC20 credit and receive the `message`.
+    #[allow(unused)]
     pub fn deposit_spl_token_and_call(
         ctx: Context<DepositSplToken>,
         amount: u64,

--- a/programs/protocol-contracts-solana/src/lib.rs
+++ b/programs/protocol-contracts-solana/src/lib.rs
@@ -113,27 +113,8 @@ pub mod gateway {
         message: Vec<u8>,
     ) -> Result<()> {
         require!(message.len() <= 512, Errors::MemoLengthExceeded);
-
-        let pda = &mut ctx.accounts.pda;
-        require!(!pda.deposit_paused, Errors::DepositPaused);
-
-        let cpi_context = CpiContext::new(
-            ctx.accounts.system_program.to_account_info(),
-            system_program::Transfer {
-                from: ctx.accounts.signer.to_account_info().clone(),
-                to: ctx.accounts.pda.to_account_info().clone(),
-            },
-        );
-        system_program::transfer(cpi_context, amount)?;
-        msg!(
-            "{:?} deposits {:?} lamports to PDA and call contract {:?} with message {:?}",
-            ctx.accounts.signer.key(),
-            amount,
-            receiver,
-            message,
-        );
-
-        Ok(())
+        deposit(ctx, amount, receiver)?;
+        return Ok(());
     }
 
     pub fn deposit_spl_token(
@@ -171,6 +152,18 @@ pub mod gateway {
         msg!("deposit spl token successfully");
 
         Ok(())
+    }
+
+
+    pub fn deposit_spl_token_and_call(
+        ctx: Context<DepositSplToken>,
+        amount: u64,
+        receiver: [u8; 20],
+        message: Vec<u8>,
+    ) -> Result<()> {
+        require!(message.len() <= 512, Errors::MemoLengthExceeded);
+        deposit_spl_token(ctx, amount, receiver)?;
+        return Ok(());
     }
 
     // only tss address stored in PDA can call this instruction

--- a/programs/protocol-contracts-solana/src/lib.rs
+++ b/programs/protocol-contracts-solana/src/lib.rs
@@ -164,7 +164,8 @@ pub mod gateway {
         return Ok(());
     }
 
-    // only tss address stored in PDA can call this instruction
+    // require tss address signature on the internal message defined in the following
+    // concatenated_buffer vec.
     pub fn withdraw(
         ctx: Context<Withdraw>,
         amount: u64,
@@ -206,7 +207,8 @@ pub mod gateway {
         Ok(())
     }
 
-    // only tss address stored in PDA can call this instruction
+    // require tss address signature on the internal message defined in the following
+    // concatenated_buffer vec.
     pub fn withdraw_spl_token(
         ctx: Context<WithdrawSPLToken>,
         amount: u64,

--- a/programs/protocol-contracts-solana/src/lib.rs
+++ b/programs/protocol-contracts-solana/src/lib.rs
@@ -48,6 +48,7 @@ pub mod gateway {
         Ok(())
     }
 
+    // admin function to pause or unpause deposit
     pub fn set_deposit_paused(ctx: Context<UpdatePaused>, deposit_paused: bool) -> Result<()> {
         let pda = &mut ctx.accounts.pda;
         require!(
@@ -84,6 +85,10 @@ pub mod gateway {
         Ok(())
     }
 
+    // deposit SOL into this program and the `receiver` on ZetaChain zEVM
+    // will get corresponding ZRC20 credit.
+    // amount: amount of lamports (10^-9 SOL) to deposit
+    // receiver: ethereum address (20Bytes) of the receiver on ZetaChain zEVM
     pub fn deposit(
         ctx: Context<Deposit>,
         amount: u64,
@@ -110,6 +115,10 @@ pub mod gateway {
         Ok(())
     }
 
+    // deposit SOL into this program and the `receiver` on ZetaChain zEVM
+    // will get corresponding ZRC20 credit. The `receiver` should be a contract
+    // on zEVM and the `message` will be used as input data for the contract call.
+    // The `receiver` contract on zEVM will get the SOL ZRC20 credit and receive the `message`.
     pub fn deposit_and_call(
         ctx: Context<Deposit>,
         amount: u64,
@@ -121,6 +130,10 @@ pub mod gateway {
         Ok(())
     }
 
+    // deposit SPL token into this program and the `receiver` on ZetaChain zEVM
+    // will get corresponding ZRC20 credit.
+    // amount: amount of SPL token to deposit
+    // receiver: ethereum address (20Bytes) of the receiver on ZetaChain zEVM
     pub fn deposit_spl_token(
         ctx: Context<DepositSplToken>,
         amount: u64,
@@ -157,6 +170,11 @@ pub mod gateway {
         Ok(())
     }
 
+    // like `deposit_spl_token` instruction,
+    // deposit SPL token into this program and the `receiver` on ZetaChain zEVM
+    // will get corresponding ZRC20 credit. The `receiver` should be a contract
+    // on zEVM and the `message` will be used as input data for the contract call.
+    // The `receiver` contract on zEVM will get the SPL token ZRC20 credit and receive the `message`.
     pub fn deposit_spl_token_and_call(
         ctx: Context<DepositSplToken>,
         amount: u64,

--- a/programs/protocol-contracts-solana/src/lib.rs
+++ b/programs/protocol-contracts-solana/src/lib.rs
@@ -139,10 +139,9 @@ pub mod gateway {
     pub fn deposit_spl_token(
         ctx: Context<DepositSplToken>,
         amount: u64,
-        memo: Vec<u8>,
+        receiver: [u8; 20],
     ) -> Result<()> {
-        require!(memo.len() >= 20, Errors::MemoLengthTooShort);
-        require!(memo.len() <= 512, Errors::MemoLengthExceeded);
+
         let token = &ctx.accounts.token_program;
         let from = &ctx.accounts.from;
 

--- a/tests/protocol-contracts-solana.ts
+++ b/tests/protocol-contracts-solana.ts
@@ -146,7 +146,7 @@ describe("some tests", () => {
         );
         tx.add(memoInst);
         const depositInst = await gatewayProgram.methods.depositSplToken(
-            new anchor.BN(1_000_000), address).accounts(
+            new anchor.BN(1_000_000), Array.from(address)).accounts(
             {
                 from: tokenAccount.address,
                 to: pda_ata.address,
@@ -157,7 +157,7 @@ describe("some tests", () => {
 
 
         try {
-            await gatewayProgram.methods.depositSplToken(new anchor.BN(1_000_000), address).accounts(
+            await gatewayProgram.methods.depositSplToken(new anchor.BN(1_000_000), Array.from(address)).accounts(
                 {
                     from: tokenAccount.address,
                     to: wallet_ata,


### PR DESCRIPTION
* refactor deposit spl token into two functions, one just deposit, and the other deposit and call.

* Refactor `deposit_and_call` and `deposit_spl_token_and_call` to reuse the `deposit` and `deposit_spl_token`. 

* added some comments on the instruction processors. 