### PR TITLE
refactor: enhance PDA validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ Mainnet-beta, testnet, devnet gateway program address:
 ZETAjseVjuFsxdRxo6MmTCvqFwb3ZHUx56Co3vCmGis
 ```
 
+The PDA account address (derived from seeds `b"meta"` and standup bump) is
+```
+2f9SLuUNb7TNeM6gzBwT4ZjbL5ZyKzzHg1Ce9yiquEjj
+```
+
 This repository hosts the smart contracts (program)
 on Solana network to support ZetaChain cross-chain
 functionality. Specifically, it consists of a single

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Mainnet-beta, testnet, devnet gateway program address:
 ZETAjseVjuFsxdRxo6MmTCvqFwb3ZHUx56Co3vCmGis
 ```
 
-The PDA account address (derived from seeds `b"meta"` and standup bump) is
+The PDA account address (derived from seeds `b"meta"` and canonical bump) is
 ```
 2f9SLuUNb7TNeM6gzBwT4ZjbL5ZyKzzHg1Ce9yiquEjj
 ```

--- a/programs/protocol-contracts-solana/src/lib.rs
+++ b/programs/protocol-contracts-solana/src/lib.rs
@@ -348,7 +348,7 @@ pub struct DepositSplToken<'info> {
     #[account(mut)]
     pub signer: Signer<'info>,
 
-    #[account(seeds=[b"meta"], bump)]
+    #[account(seeds = [b"meta"], bump)]
     pub pda: Account<'info, Pda>,
 
     pub token_program: Program<'info, Token>,

--- a/programs/protocol-contracts-solana/src/lib.rs
+++ b/programs/protocol-contracts-solana/src/lib.rs
@@ -34,7 +34,6 @@ declare_id!("ZETAjseVjuFsxdRxo6MmTCvqFwb3ZHUx56Co3vCmGis");
 
 #[program]
 pub mod gateway {
-
     use super::*;
 
     pub fn initialize(
@@ -338,8 +337,9 @@ pub struct Deposit<'info> {
     #[account(mut)]
     pub signer: Signer<'info>,
 
-    #[account(mut)]
+    #[account(mut, seeds = [b"meta"], bump)]
     pub pda: Account<'info, Pda>,
+
     pub system_program: Program<'info, System>,
 }
 
@@ -348,8 +348,9 @@ pub struct DepositSplToken<'info> {
     #[account(mut)]
     pub signer: Signer<'info>,
 
-    #[account(mut, seeds = [b"meta"], bump)]
+    #[account(seeds=[b"meta"], bump)]
     pub pda: Account<'info, Pda>,
+
     pub token_program: Program<'info, Token>,
 
     #[account(mut)]
@@ -363,7 +364,7 @@ pub struct Withdraw<'info> {
     #[account(mut)]
     pub signer: Signer<'info>,
 
-    #[account(mut)]
+    #[account(mut, seeds = [b"meta"], bump)]
     pub pda: Account<'info, Pda>,
     /// CHECK: to account is not read so no need to check its owners; the program neither knows nor cares who the owner is.
     #[account(mut)]
@@ -381,7 +382,6 @@ pub struct WithdrawSPLToken<'info> {
     #[account(mut)]
     pub pda_ata: Account<'info, TokenAccount>, // associated token address of PDA
 
-    #[account()]
     pub mint_account: Account<'info, Mint>,
 
     #[account(mut)]
@@ -392,7 +392,7 @@ pub struct WithdrawSPLToken<'info> {
 
 #[derive(Accounts)]
 pub struct UpdateTss<'info> {
-    #[account(mut)]
+    #[account(mut, seeds = [b"meta"], bump)]
     pub pda: Account<'info, Pda>,
     #[account(mut)]
     pub signer: Signer<'info>,
@@ -400,7 +400,7 @@ pub struct UpdateTss<'info> {
 
 #[derive(Accounts)]
 pub struct UpdateAuthority<'info> {
-    #[account(mut)]
+    #[account(mut, seeds = [b"meta"], bump)]
     pub pda: Account<'info, Pda>,
     #[account(mut)]
     pub signer: Signer<'info>,
@@ -408,7 +408,7 @@ pub struct UpdateAuthority<'info> {
 
 #[derive(Accounts)]
 pub struct UpdatePaused<'info> {
-    #[account(mut)]
+    #[account(mut, seeds = [b"meta"], bump)]
     pub pda: Account<'info, Pda>,
     #[account(mut)]
     pub signer: Signer<'info>,

--- a/programs/protocol-contracts-solana/src/lib.rs
+++ b/programs/protocol-contracts-solana/src/lib.rs
@@ -379,7 +379,7 @@ pub struct WithdrawSPLToken<'info> {
     #[account(mut, seeds = [b"meta"], bump)]
     pub pda: Account<'info, Pda>,
 
-    #[account(mut)]
+    #[account(mut, token::mint = mint_account, token::authority = pda)]
     pub pda_ata: Account<'info, TokenAccount>, // associated token address of PDA
 
     pub mint_account: Account<'info, Mint>,

--- a/tests/protocol-contracts-solana.ts
+++ b/tests/protocol-contracts-solana.ts
@@ -307,7 +307,7 @@ describe("some tests", () => {
     });
 
     it("deposit and withdraw 0.5 SOL from Gateway with ECDSA signature", async () => {
-        await gatewayProgram.methods.deposit(new anchor.BN(1_000_000_000), Array.from(address)).accounts({pda: pdaAccount}).rpc();
+        await gatewayProgram.methods.deposit(new anchor.BN(1_000_000_000), Array.from(address)).accounts({}).rpc();
         let bal1 = await conn.getBalance(pdaAccount);
         console.log("pda account balance", bal1);
         expect(bal1).to.be.gte(1_000_000_000);
@@ -341,7 +341,6 @@ describe("some tests", () => {
         await gatewayProgram.methods.withdraw(
             amount, Array.from(signatureBuffer), Number(recoveryParam), Array.from(message_hash), nonce)
             .accounts({
-                pda: pdaAccount,
                 to: to,
             }).rpc();
         let bal2 = await conn.getBalance(pdaAccount);
@@ -353,7 +352,7 @@ describe("some tests", () => {
 
     it("deposit and call", async () => {
         let bal1 = await conn.getBalance(pdaAccount);
-        const txsig = await gatewayProgram.methods.depositAndCall(new anchor.BN(1_000_000_000), Array.from(address), Buffer.from("hello", "utf-8")).accounts({pda: pdaAccount}).rpc({commitment: 'confirmed'});
+        const txsig = await gatewayProgram.methods.depositAndCall(new anchor.BN(1_000_000_000), Array.from(address), Buffer.from("hello", "utf-8")).accounts({}).rpc({commitment: 'confirmed'});
         const tx =  await conn.getParsedTransaction(txsig, 'confirmed');
         console.log("deposit and call parsed tx", tx);
         let bal2 = await conn.getBalance(pdaAccount);
@@ -366,7 +365,7 @@ describe("some tests", () => {
         randomFillSync(newTss);
         // console.log("generated new TSS address", newTss);
         await gatewayProgram.methods.updateTss(Array.from(newTss)).accounts({
-            pda: pdaAccount,
+
         }).rpc();
         const pdaAccountData = await gatewayProgram.account.pda.fetch(pdaAccount);
         // console.log("updated TSS address", pdaAccountData.tssAddress);
@@ -375,7 +374,6 @@ describe("some tests", () => {
         // only the authority stored in PDA can update the TSS address; the following should fail
         try {
             await gatewayProgram.methods.updateTss(Array.from(newTss)).accounts({
-                pda: pdaAccount,
                 signer: mint.publicKey,
             }).signers([mint]).rpc();
         } catch (err) {
@@ -389,12 +387,12 @@ describe("some tests", () => {
         randomFillSync(newTss);
         // console.log("generated new TSS address", newTss);
         await gatewayProgram.methods.setDepositPaused(true).accounts({
-            pda: pdaAccount,
+
         }).rpc();
 
         // now try deposit, should fail
         try {
-            await gatewayProgram.methods.depositAndCall(new anchor.BN(1_000_000), Array.from(address), Buffer.from('hi', 'utf-8')).accounts({pda: pdaAccount}).rpc();
+            await gatewayProgram.methods.depositAndCall(new anchor.BN(1_000_000), Array.from(address), Buffer.from('hi', 'utf-8')).accounts({}).rpc();
         } catch (err) {
             console.log("Error message: ", err.message);
             expect(err).to.be.instanceof(anchor.AnchorError);
@@ -405,7 +403,7 @@ describe("some tests", () => {
     it("update authority", async () => {
         const newAuthority = anchor.web3.Keypair.generate();
         await gatewayProgram.methods.updateAuthority(newAuthority.publicKey).accounts({
-            pda: pdaAccount,
+
         }).rpc();
         // const pdaAccountData = await gatewayProgram.account.pda.fetch(pdaAccount);
         // expect(pdaAccountData.authority).to.be.eq(newAuthority.publicKey);
@@ -413,7 +411,7 @@ describe("some tests", () => {
         // now the old authority cannot update TSS address and will fail
         try {
             await gatewayProgram.methods.updateTss(Array.from(new Uint8Array(20))).accounts({
-                pda: pdaAccount,
+
             }).rpc();
         } catch (err) {
             console.log("Error message: ", err.message);


### PR DESCRIPTION
Add seeds and bump to all references of PDA accounts. 

This strengthens validation. 