### PR TITLE
feat: whitelist and unwhitelist SPL tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,11 @@
 
 **Note**: Mainnet-beta, testnet, devnet gateway program address:
 
-Mainnet-beta, testnet, devnet gateway program address: 
 ```
 ZETAjseVjuFsxdRxo6MmTCvqFwb3ZHUx56Co3vCmGis
 ```
 
-The PDA account address (derived from seeds `b"meta"` and canonical bump) is
-```
-2f9SLuUNb7TNeM6gzBwT4ZjbL5ZyKzzHg1Ce9yiquEjj
-```
-
-This repository hosts the smart contracts (program)
-on Solana network to support ZetaChain cross-chain
-functionality. Specifically, it consists of a single
-program deployed
-which allows the following two actions: 
-
-1. Users on Solana network can send SOL or selected
-SPL tokens to the program to deposit into ZetaChain
-and optionally invoke a ZetaChain EVM contract. 
-2. Allows contracts on ZetaChain EVM to withdraw
-SOL and SPL tokens to users on Solana;
-3. (TO DO) In the withdraw above, optionally allow
-a contract on ZetaChain EVM to withdraw SOL/SPL tokens
-and call a user specified contract (program) with
-parameters. 
-
-
 # Introduction
-
 
 This repository hosts the smart contract (program) deployed on the Solana network to enable ZetaChain's cross-chain functionality. It consists of a single program that supports the following actions:
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ Mainnet-beta, testnet, devnet gateway program address:
 ZETAjseVjuFsxdRxo6MmTCvqFwb3ZHUx56Co3vCmGis
 ```
 
+The PDA account address (derived from seeds `b"meta"` and standup bump) is
+```
+2f9SLuUNb7TNeM6gzBwT4ZjbL5ZyKzzHg1Ce9yiquEjj
+```
+
 This repository hosts the smart contracts (program)
 on Solana network to support ZetaChain cross-chain
 functionality. Specifically, it consists of a single

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@
 ZETAjseVjuFsxdRxo6MmTCvqFwb3ZHUx56Co3vCmGis
 ```
 
+The PDA account address (derived from seeds `b"meta"` and canonical bump) is
+```
+2f9SLuUNb7TNeM6gzBwT4ZjbL5ZyKzzHg1Ce9yiquEjj
+```
+
 # Introduction
 
 This repository hosts the smart contract (program) deployed on the Solana network to enable ZetaChain's cross-chain functionality. It consists of a single program that supports the following actions:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Mainnet-beta, testnet, devnet gateway program address:
 ZETAjseVjuFsxdRxo6MmTCvqFwb3ZHUx56Co3vCmGis
 ```
 
-The PDA account address (derived from seeds `b"meta"` and standup bump) is
+The PDA account address (derived from seeds `b"meta"` and canonical bump) is
 ```
 2f9SLuUNb7TNeM6gzBwT4ZjbL5ZyKzzHg1Ce9yiquEjj
 ```

--- a/programs/protocol-contracts-solana/src/lib.rs
+++ b/programs/protocol-contracts-solana/src/lib.rs
@@ -348,7 +348,7 @@ pub struct DepositSplToken<'info> {
     #[account(mut)]
     pub signer: Signer<'info>,
 
-    #[account(seeds=[b"meta"], bump)]
+    #[account(seeds = [b"meta"], bump)]
     pub pda: Account<'info, Pda>,
 
     pub token_program: Program<'info, Token>,

--- a/programs/protocol-contracts-solana/src/lib.rs
+++ b/programs/protocol-contracts-solana/src/lib.rs
@@ -89,9 +89,13 @@ pub mod gateway {
     }
 
     // whitelisting SPL tokens
-    pub fn whitelist_spl_mint(_ctx: Context<AddToWhitelist>) -> Result<()> { Ok(()) }
+    pub fn whitelist_spl_mint(_ctx: Context<AddToWhitelist>) -> Result<()> {
+        Ok(())
+    }
 
-    pub fn de_whitelist_spl_mint(_ctx: Context<DeleteFromWhitelist>) -> Result<()> { Ok(()) }
+    pub fn de_whitelist_spl_mint(_ctx: Context<DeleteFromWhitelist>) -> Result<()> {
+        Ok(())
+    }
 
     // deposit SOL into this program and the `receiver` on ZetaChain zEVM
     // will get corresponding ZRC20 credit.
@@ -424,7 +428,6 @@ pub struct UpdatePaused<'info> {
     pub signer: Signer<'info>,
 }
 
-
 #[derive(Accounts)]
 pub struct AddToWhitelist<'info> {
     #[account(
@@ -480,8 +483,7 @@ pub struct Pda {
 }
 
 #[account]
-pub struct WhitelistEntry {
-}
+pub struct WhitelistEntry {}
 
 #[cfg(test)]
 mod tests {

--- a/programs/protocol-contracts-solana/src/lib.rs
+++ b/programs/protocol-contracts-solana/src/lib.rs
@@ -89,10 +89,9 @@ pub mod gateway {
     }
 
     // whitelisting SPL tokens
-    pub fn whitelist_spl_mint(ctx: Context<AddToWhitelist>) -> Result<()> {
+    pub fn whitelist_spl_mint(_ctx: Context<AddToWhitelist>) -> Result<()> { Ok(()) }
 
-        Ok(())
-    }
+    pub fn de_whitelist_spl_mint(_ctx: Context<DeleteFromWhitelist>) -> Result<()> { Ok(()) }
 
     // deposit SOL into this program and the `receiver` on ZetaChain zEVM
     // will get corresponding ZRC20 credit.
@@ -358,7 +357,7 @@ pub struct DepositSplToken<'info> {
     pub pda: Account<'info, Pda>,
 
     #[account(seeds=[b"whitelist", mint_account.key().as_ref()], bump)]
-    pub whitelist_entry: Account<'info, WhitelistEntry>,
+    pub whitelist_entry: Account<'info, WhitelistEntry>, // attach whitelist entry to show the mint_account is whitelisted
 
     pub mint_account: Account<'info, Mint>,
 
@@ -425,9 +424,8 @@ pub struct UpdatePaused<'info> {
     pub signer: Signer<'info>,
 }
 
-// whitelisting, dewhitelisting SPL token (mints)
+
 #[derive(Accounts)]
-// #[instruction(account_to_add: Pubkey)]
 pub struct AddToWhitelist<'info> {
     #[account(
         init,
@@ -448,7 +446,28 @@ pub struct AddToWhitelist<'info> {
     pub authority: Signer<'info>,
 
     pub system_program: Program<'info, System>,
+}
 
+#[derive(Accounts)]
+pub struct DeleteFromWhitelist<'info> {
+    #[account(
+        mut,
+        seeds=[
+            b"whitelist",
+            whitelist_candidate.key().as_ref()
+        ],
+        bump,
+        close = authority,
+    )]
+    pub whitelist_entry: Account<'info, WhitelistEntry>,
+    pub whitelist_candidate: Account<'info, Mint>,
+
+    #[account(mut, seeds = [b"meta"], bump, has_one = authority)]
+    pub pda: Account<'info, Pda>,
+    #[account(mut)]
+    pub authority: Signer<'info>,
+
+    pub system_program: Program<'info, System>,
 }
 
 #[account]

--- a/programs/protocol-contracts-solana/src/lib.rs
+++ b/programs/protocol-contracts-solana/src/lib.rs
@@ -357,6 +357,11 @@ pub struct DepositSplToken<'info> {
     #[account(seeds = [b"meta"], bump)]
     pub pda: Account<'info, Pda>,
 
+    #[account(seeds=[b"whitelist", mint_account.key().as_ref()], bump)]
+    pub whitelist_entry: Account<'info, WhitelistEntry>,
+
+    pub mint_account: Account<'info, Mint>,
+
     pub token_program: Program<'info, Token>,
 
     #[account(mut)]

--- a/programs/protocol-contracts-solana/src/lib.rs
+++ b/programs/protocol-contracts-solana/src/lib.rs
@@ -88,6 +88,12 @@ pub mod gateway {
         Ok(())
     }
 
+    // whitelisting SPL tokens
+    pub fn whitelist_spl_mint(ctx: Context<AddToWhitelist>) -> Result<()> {
+
+        Ok(())
+    }
+
     // deposit SOL into this program and the `receiver` on ZetaChain zEVM
     // will get corresponding ZRC20 credit.
     // amount: amount of lamports (10^-9 SOL) to deposit
@@ -414,6 +420,32 @@ pub struct UpdatePaused<'info> {
     pub signer: Signer<'info>,
 }
 
+// whitelisting, dewhitelisting SPL token (mints)
+#[derive(Accounts)]
+// #[instruction(account_to_add: Pubkey)]
+pub struct AddToWhitelist<'info> {
+    #[account(
+        init,
+        space=8,
+        payer=authority,
+        seeds=[
+            b"whitelist",
+            whitelist_candidate.key().as_ref()
+        ],
+        bump
+    )]
+    pub whitelist_entry: Account<'info, WhitelistEntry>,
+    pub whitelist_candidate: Account<'info, Mint>,
+
+    #[account(mut, seeds = [b"meta"], bump, has_one = authority)]
+    pub pda: Account<'info, Pda>,
+    #[account(mut)]
+    pub authority: Signer<'info>,
+
+    pub system_program: Program<'info, System>,
+
+}
+
 #[account]
 pub struct Pda {
     nonce: u64,            // ensure that each signature can only be used once
@@ -421,6 +453,10 @@ pub struct Pda {
     authority: Pubkey,
     chain_id: u64,
     deposit_paused: bool,
+}
+
+#[account]
+pub struct WhitelistEntry {
 }
 
 #[cfg(test)]

--- a/programs/protocol-contracts-solana/src/lib.rs
+++ b/programs/protocol-contracts-solana/src/lib.rs
@@ -34,7 +34,6 @@ declare_id!("ZETAjseVjuFsxdRxo6MmTCvqFwb3ZHUx56Co3vCmGis");
 
 #[program]
 pub mod gateway {
-
     use super::*;
 
     pub fn initialize(
@@ -338,8 +337,9 @@ pub struct Deposit<'info> {
     #[account(mut)]
     pub signer: Signer<'info>,
 
-    #[account(mut)]
+    #[account(mut, seeds = [b"meta"], bump)]
     pub pda: Account<'info, Pda>,
+
     pub system_program: Program<'info, System>,
 }
 
@@ -348,8 +348,9 @@ pub struct DepositSplToken<'info> {
     #[account(mut)]
     pub signer: Signer<'info>,
 
-    #[account(mut, seeds = [b"meta"], bump)]
+    #[account(seeds=[b"meta"], bump)]
     pub pda: Account<'info, Pda>,
+
     pub token_program: Program<'info, Token>,
 
     #[account(mut)]
@@ -363,7 +364,7 @@ pub struct Withdraw<'info> {
     #[account(mut)]
     pub signer: Signer<'info>,
 
-    #[account(mut)]
+    #[account(mut, seeds = [b"meta"], bump)]
     pub pda: Account<'info, Pda>,
     /// CHECK: to account is not read so no need to check its owners; the program neither knows nor cares who the owner is.
     #[account(mut)]
@@ -381,7 +382,6 @@ pub struct WithdrawSPLToken<'info> {
     #[account(mut)]
     pub pda_ata: Account<'info, TokenAccount>, // associated token address of PDA
 
-    #[account()]
     pub mint_account: Account<'info, Mint>,
 
     #[account(mut)]
@@ -392,7 +392,7 @@ pub struct WithdrawSPLToken<'info> {
 
 #[derive(Accounts)]
 pub struct UpdateTss<'info> {
-    #[account(mut)]
+    #[account(mut, seeds = [b"meta"], bump)]
     pub pda: Account<'info, Pda>,
     #[account(mut)]
     pub signer: Signer<'info>,
@@ -400,7 +400,7 @@ pub struct UpdateTss<'info> {
 
 #[derive(Accounts)]
 pub struct UpdateAuthority<'info> {
-    #[account(mut)]
+    #[account(mut, seeds = [b"meta"], bump)]
     pub pda: Account<'info, Pda>,
     #[account(mut)]
     pub signer: Signer<'info>,
@@ -408,7 +408,7 @@ pub struct UpdateAuthority<'info> {
 
 #[derive(Accounts)]
 pub struct UpdatePaused<'info> {
-    #[account(mut)]
+    #[account(mut, seeds = [b"meta"], bump)]
     pub pda: Account<'info, Pda>,
     #[account(mut)]
     pub signer: Signer<'info>,

--- a/programs/protocol-contracts-solana/src/lib.rs
+++ b/programs/protocol-contracts-solana/src/lib.rs
@@ -89,11 +89,11 @@ pub mod gateway {
     }
 
     // whitelisting SPL tokens
-    pub fn whitelist_spl_mint(_ctx: Context<AddToWhitelist>) -> Result<()> {
+    pub fn whitelist_spl_mint(_ctx: Context<Whitelist>) -> Result<()> {
         Ok(())
     }
 
-    pub fn de_whitelist_spl_mint(_ctx: Context<DeleteFromWhitelist>) -> Result<()> {
+    pub fn unwhitelist_spl_mint(_ctx: Context<Unwhitelist>) -> Result<()> {
         Ok(())
     }
 
@@ -429,7 +429,7 @@ pub struct UpdatePaused<'info> {
 }
 
 #[derive(Accounts)]
-pub struct AddToWhitelist<'info> {
+pub struct Whitelist<'info> {
     #[account(
         init,
         space=8,
@@ -452,7 +452,7 @@ pub struct AddToWhitelist<'info> {
 }
 
 #[derive(Accounts)]
-pub struct DeleteFromWhitelist<'info> {
+pub struct Unwhitelist<'info> {
     #[account(
         mut,
         seeds=[

--- a/programs/protocol-contracts-solana/src/lib.rs
+++ b/programs/protocol-contracts-solana/src/lib.rs
@@ -379,7 +379,7 @@ pub struct WithdrawSPLToken<'info> {
     #[account(mut, seeds = [b"meta"], bump)]
     pub pda: Account<'info, Pda>,
 
-    #[account(mut)]
+    #[account(mut, token::mint = mint_account, token::authority = pda)]
     pub pda_ata: Account<'info, TokenAccount>, // associated token address of PDA
 
     pub mint_account: Account<'info, Mint>,

--- a/tests/protocol-contracts-solana.ts
+++ b/tests/protocol-contracts-solana.ts
@@ -307,7 +307,7 @@ describe("some tests", () => {
     });
 
     it("deposit and withdraw 0.5 SOL from Gateway with ECDSA signature", async () => {
-        await gatewayProgram.methods.deposit(new anchor.BN(1_000_000_000), Array.from(address)).accounts({pda: pdaAccount}).rpc();
+        await gatewayProgram.methods.deposit(new anchor.BN(1_000_000_000), Array.from(address)).accounts({}).rpc();
         let bal1 = await conn.getBalance(pdaAccount);
         console.log("pda account balance", bal1);
         expect(bal1).to.be.gte(1_000_000_000);
@@ -341,7 +341,6 @@ describe("some tests", () => {
         await gatewayProgram.methods.withdraw(
             amount, Array.from(signatureBuffer), Number(recoveryParam), Array.from(message_hash), nonce)
             .accounts({
-                pda: pdaAccount,
                 to: to,
             }).rpc();
         let bal2 = await conn.getBalance(pdaAccount);
@@ -353,7 +352,7 @@ describe("some tests", () => {
 
     it("deposit and call", async () => {
         let bal1 = await conn.getBalance(pdaAccount);
-        const txsig = await gatewayProgram.methods.depositAndCall(new anchor.BN(1_000_000_000), Array.from(address), Buffer.from("hello", "utf-8")).accounts({pda: pdaAccount}).rpc({commitment: 'confirmed'});
+        const txsig = await gatewayProgram.methods.depositAndCall(new anchor.BN(1_000_000_000), Array.from(address), Buffer.from("hello", "utf-8")).accounts({}).rpc({commitment: 'confirmed'});
         const tx =  await conn.getParsedTransaction(txsig, 'confirmed');
         console.log("deposit and call parsed tx", tx);
         let bal2 = await conn.getBalance(pdaAccount);
@@ -366,7 +365,7 @@ describe("some tests", () => {
         randomFillSync(newTss);
         // console.log("generated new TSS address", newTss);
         await gatewayProgram.methods.updateTss(Array.from(newTss)).accounts({
-            pda: pdaAccount,
+
         }).rpc();
         const pdaAccountData = await gatewayProgram.account.pda.fetch(pdaAccount);
         // console.log("updated TSS address", pdaAccountData.tssAddress);
@@ -375,7 +374,6 @@ describe("some tests", () => {
         // only the authority stored in PDA can update the TSS address; the following should fail
         try {
             await gatewayProgram.methods.updateTss(Array.from(newTss)).accounts({
-                pda: pdaAccount,
                 signer: mint.publicKey,
             }).signers([mint]).rpc();
         } catch (err) {
@@ -389,12 +387,12 @@ describe("some tests", () => {
         randomFillSync(newTss);
         // console.log("generated new TSS address", newTss);
         await gatewayProgram.methods.setDepositPaused(true).accounts({
-            pda: pdaAccount,
+
         }).rpc();
 
         // now try deposit, should fail
         try {
-            await gatewayProgram.methods.depositAndCall(new anchor.BN(1_000_000), Array.from(address), Buffer.from('hi', 'utf-8')).accounts({pda: pdaAccount}).rpc();
+            await gatewayProgram.methods.depositAndCall(new anchor.BN(1_000_000), Array.from(address), Buffer.from('hi', 'utf-8')).accounts({}).rpc();
         } catch (err) {
             console.log("Error message: ", err.message);
             expect(err).to.be.instanceof(anchor.AnchorError);
@@ -405,7 +403,7 @@ describe("some tests", () => {
     it("update authority", async () => {
         const newAuthority = anchor.web3.Keypair.generate();
         await gatewayProgram.methods.updateAuthority(newAuthority.publicKey).accounts({
-            pda: pdaAccount,
+
         }).rpc();
         // const pdaAccountData = await gatewayProgram.account.pda.fetch(pdaAccount);
         // expect(pdaAccountData.authority).to.be.eq(newAuthority.publicKey);
@@ -413,7 +411,7 @@ describe("some tests", () => {
         // now the old authority cannot update TSS address and will fail
         try {
             await gatewayProgram.methods.updateTss(Array.from(new Uint8Array(20))).accounts({
-                pda: pdaAccount,
+
             }).rpc();
         } catch (err) {
             console.log("Error message: ", err.message);

--- a/tests/protocol-contracts-solana.ts
+++ b/tests/protocol-contracts-solana.ts
@@ -10,7 +10,7 @@ import {expect} from 'chai';
 import {ecdsaRecover} from 'secp256k1';
 import {getOrCreateAssociatedTokenAccount} from "@solana/spl-token";
 
-
+console.log = function() {}
 
 const ec = new EC('secp256k1');
 // const keyPair = ec.genKeyPair();
@@ -412,8 +412,8 @@ describe("some tests", () => {
         expect(bal2-bal1).to.be.gte(1_000_000_000);
     })
 
-    it("de-whitelist SPL token and deposit should fail", async () => {
-        await gatewayProgram.methods.deWhitelistSplMint().accounts({
+    it("unwhitelist SPL token and deposit should fail", async () => {
+        await gatewayProgram.methods.unwhitelistSplMint().accounts({
             whitelistCandidate: mint.publicKey,
         }).rpc();
 


### PR DESCRIPTION
closes #42 

Add whitelisting function to SPL tokens to be deposited into the program PDA. 
Right now the `authority` are authorized to whitelist/de-whitelist SPL token. 
The integration tests are also refactored somewhat to increase code reuse. 

Only `deposit_spl_token*()` instructions need to provide evidence of whitelisting. 
`withdraw_spl_token` is not encumbered by whitelisting for the following reasons: 
1. when the SPL token has never been whitelisted, there is no way to deposit into the program therefore
no way to withdraw; there is no need for witheraw_spl_token to respect whitelisting; 
2. when the SPL token was whitelisted and later de-whitelisted, the desired behavior would be to 
pause deposit, and *allow withdraw* otherwise the deposited SPL tokens will be stuck. 

Whitelisting is implemented as a special PDA for each mint account (SPL token id). 
```rust
#[derive(Accounts)]
pub struct AddToWhitelist<'info> {
    #[account(
        init,
        space=8,
        payer=authority,
        seeds=[
            b"whitelist",
            whitelist_candidate.key().as_ref()
        ],
        bump
    )]
    pub whitelist_entry: Account<'info, WhitelistEntry>,
    pub whitelist_candidate: Account<'info, Mint>,

    #[account(mut, seeds = [b"meta"], bump, has_one = authority)]
    pub pda: Account<'info, Pda>,
    #[account(mut)]
    pub authority: Signer<'info>,

    pub system_program: Program<'info, System>,
}
```

Whitelisting creates a PDA derived from the `mint_account` of the whitelisted SPL token. 
When a user deposits the whitelisted token, she must provide evidence, i.e. provide the PDA whitelist entry
in the accounts: 
```rust
#[derive(Accounts)]
pub struct DepositSplToken<'info> {
    #[account(mut)]
    pub signer: Signer<'info>,

    #[account(seeds = [b"meta"], bump)]
    pub pda: Account<'info, Pda>,

    #[account(seeds=[b"whitelist", mint_account.key().as_ref()], bump)]
    pub whitelist_entry: Account<'info, WhitelistEntry>, // attach whitelist entry to show the mint_account is whitelisted

    pub mint_account: Account<'info, Mint>,

    pub token_program: Program<'info, Token>,

    #[account(mut)]
    pub from: Account<'info, TokenAccount>, // this must be owned by signer; normally the ATA of signer
    #[account(mut)]
    pub to: Account<'info, TokenAccount>, // this must be ATA of PDA
}
```
This way, the existence of the PDA `whitelist_entry` is the evidence of the `mint_account` being whitelisted. 

De-whitelisting closes the PDA whitelist_entry so that deposit spl token will error with `AccountNotInitialized`. 

## query whitelisted status
To query whether a SPL token is whitelisted by the program off-chain, derive the `whitelist_entry` PDA account
from seeds `[b"whitelist", mint_account.key().as_ref()]` and access the PDA account. The existence of this
PDA account means whitelisted; otherwise not whitelisted. 

To query whether a SPL token is whitelisted by the program on-chain, add  evidence whitelist_entry
```
 #[account(seeds=[b"whitelist", mint_account.key().as_ref()], bump)]
    pub whitelist_entry: Account<'info, WhitelistEntry>, // attach whitelist entry to show the mint_account is whitelisted

    pub mint_account: Account<'info, Mint>,

```
to the accounts of the instruction. Anchor constraints ensures that `whitelist_entry` must exists (and initialized)
which means the referenced `mint_account` must be whitelisted. 

## testing
both positive and negative tests are in the integration test suite. 
```
$ anchor test
```