### PR TITLE
feat: enable tss auth on spl whitelisting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .anchor/
 /target
 **/.DS_Store
+node_modules

--- a/programs/protocol-contracts-solana/src/lib.rs
+++ b/programs/protocol-contracts-solana/src/lib.rs
@@ -102,7 +102,7 @@ pub mod gateway {
     ) -> Result<()> {
         let pda = &mut ctx.accounts.pda;
         let whitelist_candidate = &mut ctx.accounts.whitelist_candidate;
-        let authority =  &ctx.accounts.authority;
+        let authority = &ctx.accounts.authority;
 
         // signature provided, recover and verify that tss is the signer
         if signature != [0u8; 64] {
@@ -115,15 +115,14 @@ pub mod gateway {
                 nonce,
                 "whitelist_spl_mint",
             )?;
-        }
-        else {
+        } else {
             // no signature provided, fallback to authority check
             require!(
                 authority.key() == pda.authority,
                 Errors::SignerIsNotAuthority
             );
         }
-    
+
         Ok(())
     }
 
@@ -139,7 +138,7 @@ pub mod gateway {
     ) -> Result<()> {
         let pda = &mut ctx.accounts.pda;
         let whitelist_candidate: &mut Account<'_, Mint> = &mut ctx.accounts.whitelist_candidate;
-        let authority =  &ctx.accounts.authority;
+        let authority = &ctx.accounts.authority;
 
         // signature provided, recover and verify that tss is the signer
         if signature != [0u8; 64] {
@@ -152,8 +151,7 @@ pub mod gateway {
                 nonce,
                 "unwhitelist_spl_mint",
             )?;
-        }
-        else {
+        } else {
             // no signature provided, fallback to authority check
             require!(
                 authority.key() == pda.authority,
@@ -458,7 +456,7 @@ fn recover_eth_address(
     Ok(eth_address)
 }
 
-// recover and verify tss signature for whitelist and unwhitelist instructions 
+// recover and verify tss signature for whitelist and unwhitelist instructions
 fn validate_whitelist_tss_signature(
     pda: &mut Account<Pda>,
     whitelist_candidate: &mut Account<Mint>,

--- a/programs/protocol-contracts-solana/src/lib.rs
+++ b/programs/protocol-contracts-solana/src/lib.rs
@@ -91,11 +91,11 @@ pub mod gateway {
     }
 
     pub fn whitelist_spl_mint(
-        ctx: Context<Whitelist>, 
-        signature: [u8; 64],     
-        recovery_id: u8,         
-        message_hash: [u8; 32],   
-        nonce: u64                
+        ctx: Context<Whitelist>,
+        signature: [u8; 64],
+        recovery_id: u8,
+        message_hash: [u8; 32],
+        nonce: u64,
     ) -> Result<()> {
         let pda = &mut ctx.accounts.pda;
 
@@ -106,21 +106,21 @@ pub mod gateway {
             recovery_id,
             message_hash,
             nonce,
-            "whitelist_spl_mint"
+            "whitelist_spl_mint",
         )?;
-    
+
         Ok(())
     }
-    
+
     pub fn unwhitelist_spl_mint(
-        ctx: Context<Unwhitelist>, 
-        signature: [u8; 64],     
-        recovery_id: u8,         
-        message_hash: [u8; 32],   
-        nonce: u64
+        ctx: Context<Unwhitelist>,
+        signature: [u8; 64],
+        recovery_id: u8,
+        message_hash: [u8; 32],
+        nonce: u64,
     ) -> Result<()> {
         let pda = &mut ctx.accounts.pda;
-        
+
         validate_signature_or_authority(
             pda,
             &ctx.accounts.authority,
@@ -128,7 +128,7 @@ pub mod gateway {
             recovery_id,
             message_hash,
             nonce,
-            "unwhitelist_spl_mint"
+            "unwhitelist_spl_mint",
         )?;
 
         Ok(())
@@ -458,7 +458,7 @@ fn validate_signature_or_authority(
             msg!("ECDSA signature error");
             return err!(Errors::TSSAuthenticationFailed);
         }
-        
+
         pda.nonce += 1;
     } else {
         // no signature provided, fallback to authority check

--- a/programs/protocol-contracts-solana/src/lib.rs
+++ b/programs/protocol-contracts-solana/src/lib.rs
@@ -102,18 +102,28 @@ pub mod gateway {
     ) -> Result<()> {
         let pda = &mut ctx.accounts.pda;
         let whitelist_candidate = &mut ctx.accounts.whitelist_candidate;
+        let authority =  &ctx.accounts.authority;
 
-        validate_signature_or_authority(
-            pda,
-            whitelist_candidate,
-            &ctx.accounts.authority,
-            signature,
-            recovery_id,
-            message_hash,
-            nonce,
-            "whitelist_spl_mint",
-        )?;
-
+        // signature provided, recover and verify that tss is the signer
+        if signature != [0u8; 64] {
+            validate_whitelist_tss_signature(
+                pda,
+                whitelist_candidate,
+                signature,
+                recovery_id,
+                message_hash,
+                nonce,
+                "whitelist_spl_mint",
+            )?;
+        }
+        else {
+            // no signature provided, fallback to authority check
+            require!(
+                authority.key() == pda.authority,
+                Errors::SignerIsNotAuthority
+            );
+        }
+    
         Ok(())
     }
 
@@ -129,17 +139,27 @@ pub mod gateway {
     ) -> Result<()> {
         let pda = &mut ctx.accounts.pda;
         let whitelist_candidate: &mut Account<'_, Mint> = &mut ctx.accounts.whitelist_candidate;
+        let authority =  &ctx.accounts.authority;
 
-        validate_signature_or_authority(
-            pda,
-            whitelist_candidate,
-            &ctx.accounts.authority,
-            signature,
-            recovery_id,
-            message_hash,
-            nonce,
-            "unwhitelist_spl_mint",
-        )?;
+        // signature provided, recover and verify that tss is the signer
+        if signature != [0u8; 64] {
+            validate_whitelist_tss_signature(
+                pda,
+                whitelist_candidate,
+                signature,
+                recovery_id,
+                message_hash,
+                nonce,
+                "unwhitelist_spl_mint",
+            )?;
+        }
+        else {
+            // no signature provided, fallback to authority check
+            require!(
+                authority.key() == pda.authority,
+                Errors::SignerIsNotAuthority
+            );
+        }
 
         Ok(())
     }
@@ -438,47 +458,38 @@ fn recover_eth_address(
     Ok(eth_address)
 }
 
-fn validate_signature_or_authority(
+// recover and verify tss signature for whitelist and unwhitelist instructions 
+fn validate_whitelist_tss_signature(
     pda: &mut Account<Pda>,
     whitelist_candidate: &mut Account<Mint>,
-    authority: &Signer,
     signature: [u8; 64],
     recovery_id: u8,
     message_hash: [u8; 32],
     nonce: u64,
     instruction_name: &str,
 ) -> Result<()> {
-    // signature provided, recover and verify that tss is the signer
-    if signature != [0u8; 64] {
-        if nonce != pda.nonce {
-            msg!("mismatch nonce");
-            return err!(Errors::NonceMismatch);
-        }
-
-        let mut concatenated_buffer = Vec::new();
-        concatenated_buffer.extend_from_slice(instruction_name.as_bytes());
-        concatenated_buffer.extend_from_slice(&pda.chain_id.to_be_bytes());
-        concatenated_buffer.extend_from_slice(&whitelist_candidate.key().to_bytes());
-        concatenated_buffer.extend_from_slice(&nonce.to_be_bytes());
-        require!(
-            message_hash == hash(&concatenated_buffer[..]).to_bytes(),
-            Errors::MessageHashMismatch
-        );
-
-        let address = recover_eth_address(&message_hash, recovery_id, &signature)?;
-        if address != pda.tss_address {
-            msg!("ECDSA signature error");
-            return err!(Errors::TSSAuthenticationFailed);
-        }
-
-        pda.nonce += 1;
-    } else {
-        // no signature provided, fallback to authority check
-        require!(
-            authority.key() == pda.authority,
-            Errors::SignerIsNotAuthority
-        );
+    if nonce != pda.nonce {
+        msg!("mismatch nonce");
+        return err!(Errors::NonceMismatch);
     }
+
+    let mut concatenated_buffer = Vec::new();
+    concatenated_buffer.extend_from_slice(instruction_name.as_bytes());
+    concatenated_buffer.extend_from_slice(&pda.chain_id.to_be_bytes());
+    concatenated_buffer.extend_from_slice(&whitelist_candidate.key().to_bytes());
+    concatenated_buffer.extend_from_slice(&nonce.to_be_bytes());
+    require!(
+        message_hash == hash(&concatenated_buffer[..]).to_bytes(),
+        Errors::MessageHashMismatch
+    );
+
+    let address = recover_eth_address(&message_hash, recovery_id, &signature)?;
+    if address != pda.tss_address {
+        msg!("ECDSA signature error");
+        return err!(Errors::TSSAuthenticationFailed);
+    }
+
+    pda.nonce += 1;
 
     Ok(())
 }

--- a/tests/protocol-contracts-solana.ts
+++ b/tests/protocol-contracts-solana.ts
@@ -431,13 +431,14 @@ describe("some tests", () => {
         await depositSplTokens(gatewayProgram, conn, wallet, mint, address);
     });
 
-    it("unwhitelist SPL token using tss signature and deposit should fail", async () => {
+    it("unwhitelist SPL token using TSS signature and deposit should fail", async () => {
         const pdaAccountData = await gatewayProgram.account.pda.fetch(pdaAccount);
         const nonce = pdaAccountData.nonce;
 
         const buffer = Buffer.concat([
             Buffer.from("unwhitelist_spl_mint","utf-8"),
             chain_id_bn.toArrayLike(Buffer, 'be', 8),
+            mint.publicKey.toBuffer(),
             nonce.toArrayLike(Buffer, 'be', 8),
         ]);
         const message_hash = keccak256(buffer);
@@ -465,13 +466,14 @@ describe("some tests", () => {
         }
     });
 
-    it("re-whitelist SPL token using tss signature and deposit should succeed", async () => {
+    it("re-whitelist SPL token using TSS signature and deposit should succeed", async () => {
         const pdaAccountData = await gatewayProgram.account.pda.fetch(pdaAccount);
         const nonce = pdaAccountData.nonce;
 
         const buffer = Buffer.concat([
             Buffer.from("whitelist_spl_mint","utf-8"),
             chain_id_bn.toArrayLike(Buffer, 'be', 8),
+            mint.publicKey.toBuffer(),
             nonce.toArrayLike(Buffer, 'be', 8),
         ]);
         const message_hash = keccak256(buffer);


### PR DESCRIPTION
Currently, whitelisting has only authority check, or equivalent to admin role in evm contracts. Zetaclient is signing with tss, so whitelist should be allowed for both authority and tss, this PR modifies that.

Testing currently with this draft PR where tss signature is used for whitelisting: https://github.com/zeta-chain/node/pull/2984, and added unit tests here to verify both tss and authority work.