### PR TITLE
fix: use SPL ZRC20 withdraw fee to cover the ATA account creation rent fee 

### DIFF
--- a/programs/protocol-contracts-solana/src/lib.rs
+++ b/programs/protocol-contracts-solana/src/lib.rs
@@ -387,7 +387,7 @@ pub mod gateway {
         );
 
         let cost_gas = 5000; // default gas cost in lamports
-        let cost_ata_create = &mut 2039280; // default SPL ATA account creation rent fee in lamports
+        let cost_ata_create = &mut 0; // will be updated if ATA creation is needed
 
         // test whether the recipient_ata is created or not; if not, create it
         let recipient_ata_account = ctx.accounts.recipient_ata.to_account_info();

--- a/programs/protocol-contracts-solana/src/lib.rs
+++ b/programs/protocol-contracts-solana/src/lib.rs
@@ -338,7 +338,6 @@ pub mod gateway {
         message_hash: [u8; 32],
         nonce: u64,
     ) -> Result<()> {
-
         let pda = &mut ctx.accounts.pda;
         // let program_id = &mut ctx.accounts
         if nonce != pda.nonce {

--- a/programs/protocol-contracts-solana/src/lib.rs
+++ b/programs/protocol-contracts-solana/src/lib.rs
@@ -446,6 +446,8 @@ pub mod gateway {
         // Note: this pda.sub_lamports() must be done here due to this issue https://github.com/solana-labs/solana/issues/9711
         // otherwise the previous CPI calls might fail with error:
         // "sum of account balances before and after instruction do not match"
+        // Note2: to keep PDA from deficit, all SPL ZRC20 contracts needs to charge withdraw fee of
+        // at least 5000(gas)+2039280(rent) lamports.
         let reimbursement = cost_gas + *cost_ata_create;
         pda.sub_lamports(reimbursement)?;
         ctx.accounts.signer.add_lamports(reimbursement)?;

--- a/programs/protocol-contracts-solana/src/lib.rs
+++ b/programs/protocol-contracts-solana/src/lib.rs
@@ -167,10 +167,6 @@ pub mod gateway {
         Ok(())
     }
 
-    pub fn initialize_rent_payer(_ctx: Context<InitializeRentPayer>) -> Result<()> {
-        Ok(())
-    }
-
     // deposit SOL into this program and the `receiver` on ZetaChain zEVM
     // will get corresponding ZRC20 credit.
     // amount: amount of lamports (10^-9 SOL) to deposit
@@ -590,9 +586,6 @@ pub struct WithdrawSPLToken<'info> {
     #[account(mut)]
     pub recipient_ata: AccountInfo<'info>,
 
-    #[account(mut, seeds = [b"rent-payer"], bump)]
-    pub rent_payer_pda: Account<'info, RentPayerPda>,
-
     pub token_program: Program<'info, Token>,
 
     pub associated_token_program: Program<'info, AssociatedToken>,
@@ -669,17 +662,6 @@ pub struct Unwhitelist<'info> {
 
     #[account(mut, seeds = [b"meta"], bump)]
     pub pda: Account<'info, Pda>,
-
-    #[account(mut)]
-    pub authority: Signer<'info>,
-
-    pub system_program: Program<'info, System>,
-}
-
-#[derive(Accounts)]
-pub struct InitializeRentPayer<'info> {
-    #[account(init, payer = authority, space = 8, seeds = [b"rent-payer"], bump)]
-    pub rent_payer_pda: Account<'info, RentPayerPda>,
 
     #[account(mut)]
     pub authority: Signer<'info>,

--- a/tests/protocol-contracts-solana.ts
+++ b/tests/protocol-contracts-solana.ts
@@ -126,12 +126,6 @@ describe("Gateway", () => {
         gatewayProgram.programId,
     );
 
-    let rentPayerSeeds = [Buffer.from("rent-payer", "utf-8")];
-    let [rentPayerPdaAccount] =  anchor.web3.PublicKey.findProgramAddressSync(
-        rentPayerSeeds,
-        gatewayProgram.programId,
-    );
-
     it("Initializes the program", async () => {
         await gatewayProgram.methods.initialize(tssAddress, chain_id_bn).rpc();
 
@@ -143,18 +137,6 @@ describe("Gateway", () => {
             expect(err).to.be.not.null;
         }
     });
-    it("initialize the rent payer PDA",async() => {
-        await gatewayProgram.methods.initializeRentPayer().rpc();
-        let instr = web3.SystemProgram.transfer({
-           fromPubkey: wallet.publicKey,
-           toPubkey: rentPayerPdaAccount,
-           lamports: 100000000,
-        });
-        let tx = new web3.Transaction();
-        tx.add(instr);
-        await web3.sendAndConfirmTransaction(conn,tx,[wallet]);
-    });
-
 
     it("Mint a SPL USDC token", async () => {
         // now deploying a fake USDC SPL Token

--- a/tests/protocol-contracts-solana.ts
+++ b/tests/protocol-contracts-solana.ts
@@ -372,20 +372,12 @@ describe("Gateway", () => {
     })
 
     it("withdraw SPL token to a non-existent account should succeed by creating it", async () => {
-        let seeds = [Buffer.from("rent-payer", "utf-8")];
-        const [rentPayerPda] = anchor.web3.PublicKey.findProgramAddressSync(
-            seeds,
-            gatewayProgram.programId,
-        );
         let rentPayerPdaBal0 = await conn.getBalance(pdaAccount);
         let pda_ata = await spl.getAssociatedTokenAddress(mint.publicKey, pdaAccount, true);
         const pdaAccountData = await gatewayProgram.account.pda.fetch(pdaAccount);
-        const hexAddr = bufferToHex(Buffer.from(pdaAccountData.tssAddress));
         const amount = new anchor.BN(500_000);
         const nonce = pdaAccountData.nonce;
         const wallet2 = anchor.web3.Keypair.generate();
-
-
         const to = await spl.getAssociatedTokenAddress(mint.publicKey, wallet2.publicKey);
 
         let to_ata_bal = await conn.getBalance(to);

--- a/tests/protocol-contracts-solana.ts
+++ b/tests/protocol-contracts-solana.ts
@@ -386,8 +386,7 @@ describe("Gateway", () => {
         to_ata_bal = await conn.getBalance(to);
         expect(to_ata_bal).to.be.gt(2_000_000); // the new ata account (owned by wallet2) should be created
 
-        // rent_payer_pda should have reduced balance
-
+        // pda should have reduced balance
         let rentPayerPdaBal1 = await conn.getBalance(pdaAccount);
         // expected reimbursement to be gas fee (5000 lamports) + ATA creation cost 2039280 lamports
         expect(rentPayerPdaBal0-rentPayerPdaBal1).to.be.eq(to_ata_bal + 5000); // rentPayer pays rent


### PR DESCRIPTION
closes #63 
closes #4 

conflicts with PR #65 : should only consider merging one. 

**important**: all ZRC20 of SPL tokens must charge at least 2039280 lamports (0.002039280 SOL) as withdraw fee, otherwise the program PDA account might run into deficit. 

