### PR TITLE
ci: set protocol team as maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*     @brewmaster012 @lumtis @ws4charlie @skosito
+* @zeta-chain/protocol-engineering

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .anchor/
+.idea/
 /target
 **/.DS_Store
 node_modules


### PR DESCRIPTION
Will simplify maintenance, we can always coordinate ourselves when we require the review from someone specific