### PR TITLE
feat: use separate program id for dev env

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         toolchain: stable
     - name: cargo install avm
-      run: cargo install avm
+      run: cargo install --git https://github.com/coral-xyz/anchor avm --locked --force
     - name: Print Cargo, Rustup, and AVM versions
       run: |
         echo "=== Version Information ==="

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         toolchain: stable
     - name: cargo install avm
-      uses: cargo install avm
+      run: cargo install avm
     - name: Print Cargo, Rustup, and AVM versions
       run: |
         echo "=== Version Information ==="

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v4
+    - name: Install ${{ matrix.toolchain }}
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ matrix.toolchain }}
     - uses: metadaoproject/anchor-test@v2.1
       with: 
         anchor-version: '0.30.1'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,8 @@ jobs:
       uses: dtolnay/rust-toolchain@master
       with:
         toolchain: stable
+    - name: cargo install avm
+      uses: cargo install avm
     - name: Print Cargo, Rustup, and AVM versions
       run: |
         echo "=== Version Information ==="

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,6 @@ jobs:
     - uses: metadaoproject/anchor-test@v2.1
       with: 
         anchor-version: '0.30.1'
-        solana-cli-version: '1.18.23'
+        solana-cli-version: '1.18.25'
         node-version: '21.1.0'
   

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,6 @@ jobs:
     - uses: metadaoproject/anchor-test@v2.1
       with: 
         anchor-version: '0.30.1'
-        solana-cli-version: '1.18.18'
+        solana-cli-version: '1.18.23'
         node-version: '21.1.0'
   

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v4
-    - name: Install ${{ matrix.toolchain }}
+    - name: Install stable rust toolchain
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: ${{ matrix.toolchain }}
+        toolchain: stable
     - uses: metadaoproject/anchor-test@v2.1
       with: 
         anchor-version: '0.30.1'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,12 +5,12 @@ on:
   pull_request:
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v4
     - uses: metadaoproject/anchor-test@v2.1
       with: 
-        anchor-version: '0.30.1-ca7fcee6b8269b732b66536f72ff3fb48cf1b5f9'
+        anchor-version: '0.30.1'
         solana-cli-version: '1.18.18'
         node-version: '21.1.0'
   

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: metadaoproject/anchor-test@v2.1
       with: 
-        anchor-version: '0.30.1'
+        anchor-version: '0.30.1-ca7fcee6b8269b732b66536f72ff3fb48cf1b5f9'
         solana-cli-version: '1.18.25'
         node-version: '21.1.0'
   

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,6 @@ jobs:
         toolchain: stable
     - name: cargo install avm
       run: cargo install --git https://github.com/coral-xyz/anchor avm --locked --force
-    - name: Print Cargo, Rustup, and AVM versions
-      run: |
-        echo "=== Version Information ==="
-        cargo --version || echo "Cargo not found"
-        rustup --version || echo "Rustup not found"
-        avm --version || echo "AVM not found"
     - uses: metadaoproject/anchor-test@v2.1
       with: 
         anchor-version: '0.30.1'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: cargo install avm
-      run: cargo install --git https://github.com/coral-xyz/anchor avm --locked --force
+      run: cargo install --git https://github.com/coral-xyz/anchor avm
     - uses: metadaoproject/anchor-test@v2.1
       with: 
         anchor-version: '0.30.1'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,6 @@ jobs:
     - uses: metadaoproject/anchor-test@v2.1
       with: 
         anchor-version: '0.30.1-ca7fcee6b8269b732b66536f72ff3fb48cf1b5f9'
-        solana-cli-version: '1.18.25'
+        solana-cli-version: '1.18.18'
         node-version: '21.1.0'
   

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,12 @@ jobs:
       uses: dtolnay/rust-toolchain@master
       with:
         toolchain: stable
+    - name: Print Cargo, Rustup, and AVM versions
+      run: |
+        echo "=== Version Information ==="
+        cargo --version || echo "Cargo not found"
+        rustup --version || echo "Rustup not found"
+        avm --version || echo "AVM not found"
     - uses: metadaoproject/anchor-test@v2.1
       with: 
         anchor-version: '0.30.1'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,13 +5,9 @@ on:
   pull_request:
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Install stable rust toolchain
-      uses: dtolnay/rust-toolchain@master
-      with:
-        toolchain: stable
     - name: cargo install avm
       run: cargo install --git https://github.com/coral-xyz/anchor avm --locked --force
     - uses: metadaoproject/anchor-test@v2.1

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -1,4 +1,5 @@
 [toolchain]
+anchor_version = "0.30.1-ca7fcee6b8269b732b66536f72ff3fb48cf1b5f9"
 
 [workspace]
 members = [

--- a/programs/gateway/Cargo.toml
+++ b/programs/gateway/Cargo.toml
@@ -15,6 +15,7 @@ no-entrypoint = []
 no-idl = []
 no-log-ix-name = []
 idl-build = ["anchor-lang/idl-build"]
+dev = []
 
 [dependencies]
 anchor-lang = { version = "=0.30.0" }

--- a/programs/gateway/src/lib.rs
+++ b/programs/gateway/src/lib.rs
@@ -46,6 +46,9 @@ enum InstructionId {
     IncrementNonce = 7,
 }
 
+#[cfg(feature = "dev")]
+declare_id!("94U5AHQMKkV5txNJ17QPXWoh474PheGou6cNP2FEuL1d");
+#[cfg(not(feature = "dev"))]
 declare_id!("ZETAjseVjuFsxdRxo6MmTCvqFwb3ZHUx56Co3vCmGis");
 
 #[repr(C)]


### PR DESCRIPTION
Using `features` it is possible to toggle between different program ids.

However, in latest anchor 0.30.1 there is a bug preventing that https://github.com/coral-xyz/anchor/issues/3465

It is stated in issue that fixed commit can be used. Normally it is not ok to use non-released version like this, but this is just couple of commits after 0.30.1, and all those commits are not breaking or anything that would have impact.

With this, `anchor build` would work like currently, and `anchor build -- --features="dev"` would create IDL with dev program id we use for development in localnet, node etc.