### PR TITLE
fix: use connected pda seed for execute and execute spl

### DIFF
--- a/programs/examples/connectedSPL/src/lib.rs
+++ b/programs/examples/connectedSPL/src/lib.rs
@@ -30,7 +30,7 @@ pub mod connected_spl {
 
         // Transfer some portion of tokens transferred from gateway to another account
         let token = &ctx.accounts.token_program;
-        let signer_seeds: &[&[&[u8]]] = &[&[b"connectedSPL", &[ctx.bumps.pda]]];
+        let signer_seeds: &[&[&[u8]]] = &[&[b"connected", &[ctx.bumps.pda]]];
 
         let xfer_ctx = CpiContext::new_with_signer(
             token.to_account_info(),
@@ -67,7 +67,7 @@ pub struct Initialize<'info> {
     #[account(mut)]
     pub signer: Signer<'info>,
 
-    #[account(init, payer = signer, space = size_of::<Pda>() + 32, seeds = [b"connectedSPL"], bump)]
+    #[account(init, payer = signer, space = size_of::<Pda>() + 32, seeds = [b"connected"], bump)]
     pub pda: Account<'info, Pda>,
 
     pub system_program: Program<'info, System>,
@@ -75,7 +75,7 @@ pub struct Initialize<'info> {
 
 #[derive(Accounts)]
 pub struct OnCall<'info> {
-    #[account(mut, seeds = [b"connectedSPL"], bump)]
+    #[account(mut, seeds = [b"connected"], bump)]
     pub pda: Account<'info, Pda>,
 
     #[account(mut)]

--- a/tests/gateway.ts
+++ b/tests/gateway.ts
@@ -949,7 +949,7 @@ describe("Gateway", () => {
     );
     const lastMessageData = "execute_spl";
     const data = Buffer.from(lastMessageData, "utf-8");
-    let seeds = [Buffer.from("connectedSPL", "utf-8")];
+    let seeds = [Buffer.from("connected", "utf-8")];
     const [connectedPdaAccount] = anchor.web3.PublicKey.findProgramAddressSync(
       seeds,
       connectedSPLProgram.programId
@@ -1074,7 +1074,7 @@ describe("Gateway", () => {
     );
     const lastMessageData = "revert";
     const data = Buffer.from(lastMessageData, "utf-8");
-    let seeds = [Buffer.from("connectedSPL", "utf-8")];
+    let seeds = [Buffer.from("connected", "utf-8")];
     const [connectedPdaAccount] = anchor.web3.PublicKey.findProgramAddressSync(
       seeds,
       connectedSPLProgram.programId
@@ -1189,7 +1189,7 @@ describe("Gateway", () => {
     );
     const lastMessageData = "revert";
     const data = Buffer.from(lastMessageData, "utf-8");
-    let seeds = [Buffer.from("connectedSPL", "utf-8")];
+    let seeds = [Buffer.from("connected", "utf-8")];
     const [connectedPdaAccount] = anchor.web3.PublicKey.findProgramAddressSync(
       seeds,
       connectedSPLProgram.programId
@@ -1306,7 +1306,7 @@ describe("Gateway", () => {
     );
     const lastMessageData = "revert";
     const data = Buffer.from(lastMessageData, "utf-8");
-    let seeds = [Buffer.from("connectedSPL", "utf-8")];
+    let seeds = [Buffer.from("connected", "utf-8")];
     const [connectedPdaAccount] = anchor.web3.PublicKey.findProgramAddressSync(
       seeds,
       connectedSPLProgram.programId


### PR DESCRIPTION
No need to have separate seed in connected program if executeSPL is called. That would mean if user uses 1 program to handle both, they would have to initialize 2 pda accounts with different seeds.