### PR TITLE
fix: revert mut on destination program pda

### DIFF
--- a/programs/gateway/src/lib.rs
+++ b/programs/gateway/src/lib.rs
@@ -1012,7 +1012,6 @@ pub struct Execute<'info> {
     // Pda for destination program
     /// CHECK: Validation will occur during instruction processing.
     #[account(
-        mut,
         seeds = [b"connected"],
         bump,
         seeds::program = destination_program.key()
@@ -1166,7 +1165,6 @@ pub struct ExecuteSPLToken<'info> {
     // Pda for destination program
     /// CHECK: Validation will occur during instruction processing.
     #[account(
-        mut,
         seeds = [b"connected"],
         bump,
         seeds::program = destination_program.key()


### PR DESCRIPTION
accidentally modified here to be mut even though its not needed: https://github.com/zeta-chain/protocol-contracts-solana/pull/90