### PR TITLE
feat: add revert options to inbound functions

### DIFF
--- a/programs/gateway/src/lib.rs
+++ b/programs/gateway/src/lib.rs
@@ -99,12 +99,14 @@ impl CallableInstruction {
 /// Struct containing revert options
 /// # Arguments
 /// * `revert_address` Address to receive revert.
+/// * `abort_address` Address to receive funds if aborted.
 /// * `call_on_revert` Flag if on_revert hook should be called.
 /// * `revert_message` Arbitrary data sent back in on_revert.
 /// * `on_revert_gas_limit` Gas limit for revert tx.
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
 pub struct RevertOptions {
     pub revert_address: Pubkey,
+    pub abort_address: Pubkey,
     pub call_on_revert: bool,
     pub revert_message: Vec<u8>,
     pub on_revert_gas_limit: u64,

--- a/programs/gateway/src/lib.rs
+++ b/programs/gateway/src/lib.rs
@@ -96,6 +96,20 @@ impl CallableInstruction {
     }
 }
 
+/// Struct containing revert options
+/// # Arguments
+/// * `revert_address` Address to receive revert.
+/// * `call_on_revert` Flag if on_revert hook should be called.
+/// * `revert_message` Arbitrary data sent back in on_revert.
+/// * `on_revert_gas_limit` Gas limit for revert tx.
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub struct RevertOptions {
+    pub revert_address: Pubkey,
+    pub call_on_revert: bool,
+    pub revert_message: Vec<u8>,
+    pub on_revert_gas_limit: u64,
+}
+
 #[program]
 pub mod gateway {
     use super::*;
@@ -105,7 +119,7 @@ pub mod gateway {
     /// Prefix used for outbounds message hashes.
     pub const ZETACHAIN_PREFIX: &[u8] = b"ZETACHAIN";
     /// Max deposit payload size
-    const MAX_DEPOSIT_PAYLOAD_SIZE: usize = 750;
+    const MAX_DEPOSIT_PAYLOAD_SIZE: usize = 745;
 
     /// Initializes the gateway PDA.
     ///
@@ -536,7 +550,19 @@ pub mod gateway {
     /// * `ctx` - The instruction context.
     /// * `amount` - The amount of lamports to deposit.
     /// * `receiver` - The Ethereum address of the receiver on ZetaChain zEVM.
-    pub fn deposit(ctx: Context<Deposit>, amount: u64, receiver: [u8; 20]) -> Result<()> {
+    /// * `revert_options` - Revert options.
+    pub fn deposit(
+        ctx: Context<Deposit>,
+        amount: u64,
+        receiver: [u8; 20],
+        revert_options: Option<RevertOptions>,
+    ) -> Result<()> {
+        if let Some(opts) = &revert_options {
+            require!(
+                opts.revert_message.len() <= MAX_DEPOSIT_PAYLOAD_SIZE,
+                Errors::MemoLengthExceeded
+            );
+        }
         let pda = &mut ctx.accounts.pda;
         require!(!pda.deposit_paused, Errors::DepositPaused);
         require!(receiver != [0u8; 20], Errors::EmptyReceiver);
@@ -552,11 +578,12 @@ pub mod gateway {
         system_program::transfer(cpi_context, amount_with_fees)?;
 
         msg!(
-            "Deposit executed: amount = {}, fee = {}, receiver = {:?}, pda = {}",
+            "Deposit executed: amount = {}, fee = {}, receiver = {:?}, pda = {}, revert options = {:?}",
             amount,
             DEPOSIT_FEE,
             receiver,
-            ctx.accounts.pda.key()
+            ctx.accounts.pda.key(),
+            revert_options
         );
 
         Ok(())
@@ -569,17 +596,24 @@ pub mod gateway {
     /// * `amount` - The amount of lamports to deposit.
     /// * `receiver` - The Ethereum address of the receiver on ZetaChain zEVM.
     /// * `message` - The message passed to the contract.
+    /// * `revert_options` - Revert options.
     pub fn deposit_and_call(
         ctx: Context<Deposit>,
         amount: u64,
         receiver: [u8; 20],
         message: Vec<u8>,
+        revert_options: Option<RevertOptions>,
     ) -> Result<()> {
+        let revert_message_len = revert_options
+            .as_ref()
+            .and_then(|opts| Some(opts.revert_message.len()))
+            .unwrap_or(0);
+
         require!(
-            message.len() <= MAX_DEPOSIT_PAYLOAD_SIZE,
+            message.len() + revert_message_len <= MAX_DEPOSIT_PAYLOAD_SIZE,
             Errors::MemoLengthExceeded
         );
-        deposit(ctx, amount, receiver)?;
+        deposit(ctx, amount, receiver, revert_options)?;
 
         msg!("Deposit and call executed with message = {:?}", message);
 
@@ -592,11 +626,19 @@ pub mod gateway {
     /// * `ctx` - The instruction context.
     /// * `amount` - The amount of SPL tokens to deposit.
     /// * `receiver` - The Ethereum address of the receiver on ZetaChain zEVM.
+    /// * `revert_options` - Revert options.
     pub fn deposit_spl_token(
         ctx: Context<DepositSplToken>,
         amount: u64,
         receiver: [u8; 20],
+        revert_options: Option<RevertOptions>,
     ) -> Result<()> {
+        if let Some(opts) = &revert_options {
+            require!(
+                opts.revert_message.len() <= MAX_DEPOSIT_PAYLOAD_SIZE,
+                Errors::MemoLengthExceeded
+            );
+        }
         let token = &ctx.accounts.token_program;
         let from = &ctx.accounts.from;
 
@@ -630,12 +672,13 @@ pub mod gateway {
         transfer(xfer_ctx, amount)?;
 
         msg!(
-            "Deposit SPL executed: amount = {}, fee = {}, receiver = {:?}, pda = {}, mint = {}",
+            "Deposit SPL executed: amount = {}, fee = {}, receiver = {:?}, pda = {}, mint = {}, revert options = {:?}",
             amount,
             DEPOSIT_FEE,
             receiver,
             ctx.accounts.pda.key(),
-            ctx.accounts.mint_account.key()
+            ctx.accounts.mint_account.key(),
+            revert_options
         );
 
         Ok(())
@@ -648,17 +691,24 @@ pub mod gateway {
     /// * `amount` - The amount of SPL tokens to deposit.
     /// * `receiver` - The Ethereum address of the receiver on ZetaChain zEVM.
     /// * `message` - The message passed to the contract.
+    /// * `revert_options` - Revert options.
     pub fn deposit_spl_token_and_call(
         ctx: Context<DepositSplToken>,
         amount: u64,
         receiver: [u8; 20],
         message: Vec<u8>,
+        revert_options: Option<RevertOptions>,
     ) -> Result<()> {
+        let revert_message_len = revert_options
+            .as_ref()
+            .and_then(|opts| Some(opts.revert_message.len()))
+            .unwrap_or(0);
+
         require!(
-            message.len() <= MAX_DEPOSIT_PAYLOAD_SIZE,
+            message.len() + revert_message_len <= MAX_DEPOSIT_PAYLOAD_SIZE,
             Errors::MemoLengthExceeded
         );
-        deposit_spl_token(ctx, amount, receiver)?;
+        deposit_spl_token(ctx, amount, receiver, revert_options)?;
 
         msg!("Deposit SPL and call executed with message = {:?}", message);
 
@@ -671,17 +721,29 @@ pub mod gateway {
     /// * `ctx` - The instruction context.
     /// * `receiver` - The Ethereum address of the receiver on ZetaChain zEVM.
     /// * `message` - The message passed to the contract.
-    pub fn call(_ctx: Context<Call>, receiver: [u8; 20], message: Vec<u8>) -> Result<()> {
+    /// * `revert_options` - Revert options.
+    pub fn call(
+        _ctx: Context<Call>,
+        receiver: [u8; 20],
+        message: Vec<u8>,
+        revert_options: Option<RevertOptions>,
+    ) -> Result<()> {
         require!(receiver != [0u8; 20], Errors::EmptyReceiver);
+        let revert_message_len = revert_options
+            .as_ref()
+            .and_then(|opts| Some(opts.revert_message.len()))
+            .unwrap_or(0);
+
         require!(
-            message.len() <= MAX_DEPOSIT_PAYLOAD_SIZE,
+            message.len() + revert_message_len <= MAX_DEPOSIT_PAYLOAD_SIZE,
             Errors::MemoLengthExceeded
         );
 
         msg!(
-            "Call executed: receiver = {:?}, message = {:?}",
+            "Call executed: receiver = {:?}, message = {:?}, revert options = {:?}",
             receiver,
-            message
+            message,
+            revert_options
         );
 
         Ok(())

--- a/tests/gateway.ts
+++ b/tests/gateway.ts
@@ -21,7 +21,15 @@ const keyPair = ec.keyFromPrivate(
 const usdcDecimals = 6;
 const chain_id = 111111;
 const chain_id_bn = new anchor.BN(chain_id);
-const maxPayloadSize = 750;
+const maxPayloadSize = 745;
+
+// generic revertOptions
+const revertOptions = {
+  revertAddress: anchor.web3.Keypair.generate().publicKey,
+  callOnRevert: false,
+  revertMessage: Buffer.from("", "utf-8"),
+  onRevertGasLimit: new anchor.BN(0),
+};
 
 async function mintSPLToken(
   conn: anchor.web3.Connection,
@@ -80,7 +88,11 @@ async function depositSplTokens(
     wallet.publicKey
   );
   await gatewayProgram.methods
-    .depositSplToken(new anchor.BN(1_000_000), Array.from(address))
+    .depositSplToken(
+      new anchor.BN(1_000_000),
+      Array.from(address),
+      revertOptions
+    )
     .accounts({
       from: tokenAccount.address,
       to: pda_ata.address,
@@ -263,13 +275,17 @@ describe("Gateway", () => {
         .depositSplTokenAndCall(
           new anchor.BN(2_000_000),
           Array.from(address),
-          Buffer.from(Array(maxPayloadSize + 1).fill(1))
+          Buffer.from(Array(maxPayloadSize + 1).fill(1)),
+          null
         )
         .accounts({
           from: tokenAccount.address,
           to: pda_ata.address,
           mintAccount: mint.publicKey,
         })
+        .preInstructions([
+          ComputeBudgetProgram.setComputeUnitLimit({ units: 400000 }),
+        ])
         .rpc({ commitment: "processed" });
       throw new Error("Expected error not thrown");
     } catch (err) {
@@ -299,7 +315,8 @@ describe("Gateway", () => {
       .depositSplTokenAndCall(
         new anchor.BN(2_000_000),
         Array.from(address),
-        Buffer.from(Array(maxPayloadSize).fill(1))
+        Buffer.from(Array(maxPayloadSize).fill(1)),
+        null
       )
       .accounts({
         from: tokenAccount.address,
@@ -338,7 +355,11 @@ describe("Gateway", () => {
     );
     try {
       await gatewayProgram.methods
-        .depositSplToken(new anchor.BN(1_000_000), Array.from(address))
+        .depositSplToken(
+          new anchor.BN(1_000_000),
+          Array.from(address),
+          revertOptions
+        )
         .accounts({
           from: tokenAccount.address,
           to: wallet_ata,
@@ -358,7 +379,8 @@ describe("Gateway", () => {
       .depositSplTokenAndCall(
         new anchor.BN(2_000_000),
         Array.from(address),
-        Buffer.from("hi", "utf-8")
+        Buffer.from("hi", "utf-8"),
+        revertOptions
       )
       .accounts({
         from: tokenAccount.address,
@@ -394,7 +416,11 @@ describe("Gateway", () => {
     );
     try {
       await gatewayProgram.methods
-        .depositSplToken(new anchor.BN(1_000_000), Array.from(address))
+        .depositSplToken(
+          new anchor.BN(1_000_000),
+          Array.from(address),
+          revertOptions
+        )
         .accounts({
           from: tokenAccount.address,
           to: fake_pda_ata.address,
@@ -498,7 +524,7 @@ describe("Gateway", () => {
   it("Deposit if receiver is empty address should fail", async () => {
     try {
       await gatewayProgram.methods
-        .deposit(new anchor.BN(1_000_000_000), Array(20).fill(0))
+        .deposit(new anchor.BN(1_000_000_000), Array(20).fill(0), revertOptions)
         .rpc();
       throw new Error("Expected error not thrown");
     } catch (err) {
@@ -509,7 +535,7 @@ describe("Gateway", () => {
 
   it("Deposit and withdraw 0.5 SOL from Gateway with ECDSA signature", async () => {
     await gatewayProgram.methods
-      .deposit(new anchor.BN(1_000_000_000), Array.from(address))
+      .deposit(new anchor.BN(1_000_000_000), Array.from(address), revertOptions)
       .rpc();
     let bal1 = await conn.getBalance(pdaAccount);
     // amount + deposit fee
@@ -694,7 +720,7 @@ describe("Gateway", () => {
   it("Calls execute and onCall", async () => {
     await connectedProgram.methods.initialize().rpc();
     await gatewayProgram.methods
-      .deposit(new anchor.BN(1_000_000_000), Array.from(address))
+      .deposit(new anchor.BN(1_000_000_000), Array.from(address), revertOptions)
       .rpc();
 
     const randomWallet = anchor.web3.Keypair.generate();
@@ -792,7 +818,7 @@ describe("Gateway", () => {
 
   it("Calls execute and onCall reverts if connected program reverts", async () => {
     await gatewayProgram.methods
-      .deposit(new anchor.BN(1_000_000_000), Array.from(address))
+      .deposit(new anchor.BN(1_000_000_000), Array.from(address), revertOptions)
       .rpc();
 
     const randomWallet = anchor.web3.Keypair.generate();
@@ -864,7 +890,7 @@ describe("Gateway", () => {
 
   it("Calls execute and onCall reverts if wrong msg hash", async () => {
     await gatewayProgram.methods
-      .deposit(new anchor.BN(1_000_000_000), Array.from(address))
+      .deposit(new anchor.BN(1_000_000_000), Array.from(address), revertOptions)
       .rpc();
 
     const randomWallet = anchor.web3.Keypair.generate();
@@ -938,7 +964,7 @@ describe("Gateway", () => {
   it("Calls execute and onCall reverts if wrong signer", async () => {
     const key = ec.genKeyPair(); // non TSS key pair
     await gatewayProgram.methods
-      .deposit(new anchor.BN(1_000_000_000), Array.from(address))
+      .deposit(new anchor.BN(1_000_000_000), Array.from(address), revertOptions)
       .rpc();
 
     const randomWallet = anchor.web3.Keypair.generate();
@@ -1011,7 +1037,7 @@ describe("Gateway", () => {
 
   it("Calls execute and onCall reverts if signer is passed in remaining accounts", async () => {
     await gatewayProgram.methods
-      .deposit(new anchor.BN(1_000_000_000), Array.from(address))
+      .deposit(new anchor.BN(1_000_000_000), Array.from(address), revertOptions)
       .rpc();
 
     const randomWallet = anchor.web3.Keypair.generate();
@@ -1862,7 +1888,8 @@ describe("Gateway", () => {
         .depositAndCall(
           new anchor.BN(1_000_000_000),
           Array(20).fill(0),
-          Buffer.from("hello", "utf-8")
+          Buffer.from("hello", "utf-8"),
+          revertOptions
         )
         .rpc();
       throw new Error("Expected error not thrown");
@@ -1878,7 +1905,8 @@ describe("Gateway", () => {
         .depositAndCall(
           new anchor.BN(1_000_000_000),
           Array.from(address),
-          Buffer.from(Array(maxPayloadSize + 1).fill(1))
+          Buffer.from(Array(maxPayloadSize + 1).fill(1)),
+          revertOptions
         )
         .rpc();
       throw new Error("Expected error not thrown");
@@ -1891,7 +1919,7 @@ describe("Gateway", () => {
   it("Call with empty address receiver should fail", async () => {
     try {
       await gatewayProgram.methods
-        .call(Array(20).fill(0), Buffer.from("hello", "utf-8"))
+        .call(Array(20).fill(0), Buffer.from("hello", "utf-8"), revertOptions)
         .rpc();
       throw new Error("Expected error not thrown");
     } catch (err) {
@@ -1905,7 +1933,8 @@ describe("Gateway", () => {
       await gatewayProgram.methods
         .call(
           Array.from(address),
-          Buffer.from(Array(maxPayloadSize + 1).fill(1))
+          Buffer.from(Array(maxPayloadSize + 1).fill(1)),
+          revertOptions
         )
         .rpc();
       throw new Error("Expected error not thrown");
@@ -1917,7 +1946,11 @@ describe("Gateway", () => {
 
   it("Call with max payload size", async () => {
     const txsig = await gatewayProgram.methods
-      .call(Array.from(address), Buffer.from(Array(maxPayloadSize).fill(1)))
+      .call(
+        Array.from(address),
+        Buffer.from(Array(maxPayloadSize).fill(1)),
+        revertOptions
+      )
       .preInstructions([
         ComputeBudgetProgram.setComputeUnitLimit({ units: 400000 }),
       ])
@@ -1931,7 +1964,8 @@ describe("Gateway", () => {
       .depositAndCall(
         new anchor.BN(1_000_000_000),
         Array.from(address),
-        Buffer.from(Array(maxPayloadSize).fill(1))
+        Buffer.from(Array(maxPayloadSize).fill(1)),
+        revertOptions
       )
       .preInstructions([
         ComputeBudgetProgram.setComputeUnitLimit({ units: 400000 }),
@@ -1948,7 +1982,8 @@ describe("Gateway", () => {
       .depositAndCall(
         new anchor.BN(1_000_000_000),
         Array.from(address),
-        Buffer.from("hello", "utf-8")
+        Buffer.from("hello", "utf-8"),
+        revertOptions
       )
       .rpc({ commitment: "processed" });
     await conn.getParsedTransaction(txsig, "confirmed");
@@ -2221,7 +2256,8 @@ describe("Gateway", () => {
         .depositAndCall(
           new anchor.BN(1_000_000),
           Array.from(address),
-          Buffer.from("hi", "utf-8")
+          Buffer.from("hi", "utf-8"),
+          revertOptions
         )
         .rpc();
       throw new Error("Expected error not thrown");

--- a/tests/gateway.ts
+++ b/tests/gateway.ts
@@ -26,6 +26,7 @@ const maxPayloadSize = 745;
 // generic revertOptions
 const revertOptions = {
   revertAddress: anchor.web3.Keypair.generate().publicKey,
+  abortAddress: anchor.web3.Keypair.generate().publicKey,
   callOnRevert: false,
   revertMessage: Buffer.from("", "utf-8"),
   onRevertGasLimit: new anchor.BN(0),


### PR DESCRIPTION
- add revertOptions to all inbound functions
- adding this struct as mandatory increases tx size, so it is optional
- need to decrease max payload size a bit (750 -> 745) even if its optional, so deposit spl and call works for cases where max payload is used, othewise solana tx is too big and reverts