### PR TITLE
feat: deposit through example program

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,6 +508,7 @@ version = "0.1.0"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
+ "gateway",
  "spl-associated-token-account",
 ]
 

--- a/programs/examples/connected/Cargo.toml
+++ b/programs/examples/connected/Cargo.toml
@@ -20,3 +20,4 @@ idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
 anchor-lang = { version = "=0.31.1" }
 anchor-spl = { version = "=0.31.1" }
 spl-associated-token-account = { version = "6.0.0", features = ["no-entrypoint"] }
+gateway = { path = "../../gateway", features = ["no-entrypoint", "cpi"] }


### PR DESCRIPTION
call gateway deposit through example `connected` program, used to test new event parsing feature for inner instructions