### PR TITLE
fix: npm package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@zetachain/gateway",
+  "name": "@zetachain/protocol-contracts-solana",
   "private": false,
   "license": "MIT",
   "version": "0.0.0-set-on-publish",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "description": "Package contains IDL and shared object files for the Solana Gateway program, enabling cross-chain functionality with ZetaChain",
   "files": [
     "prod",
-    "dev"
+    "dev",
+    "index.js"
   ],
   "scripts": {
     "fmt:fix": "prettier */*.js \"*/**/*{.js,.ts}\" -w",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,8 @@
   "version": "0.0.0-set-on-publish",
   "description": "Package contains IDL and shared object files for the Solana Gateway program, enabling cross-chain functionality with ZetaChain",
   "files": [
-    "mainnet",
-    "testnet",
-    "index.js"
+    "prod",
+    "dev"
   ],
   "scripts": {
     "fmt:fix": "prettier */*.js \"*/**/*{.js,.ts}\" -w",


### PR DESCRIPTION
The package name at some point was mistakingly changed to `@zetachain/gateway`. This reverts package name back to `@zetachain/protocol-contracts-solana`.

We've accidentally published https://www.npmjs.com/package/@zetachain/gateway/v/3.0.2-rc1?activeTab=code

Which actually showed us that `dev` and `prod` are not being included in the package, so I've added this directories to `package.json` so that they're properly included when published.