### PR TITLE
fix: deposit spl from field constraint v29

### DIFF
--- a/programs/gateway/src/lib.rs
+++ b/programs/gateway/src/lib.rs
@@ -1059,7 +1059,7 @@ pub struct DepositSplToken<'info> {
     pub token_program: Program<'info, Token>,
 
     /// The source token account owned by the signer.
-    #[account(mut)]
+    #[account(mut, constraint = from.mint == mint_account.key())]
     pub from: Account<'info, TokenAccount>,
 
     /// The destination token account owned by the PDA.


### PR DESCRIPTION
CI test failing is expected, locally it can be run with:

```
RUSTUP_TOOLCHAIN=nightly-2025-04-14 anchor test
```

fixed on main branch by anchor upgrade, and more details here: https://github.com/zeta-chain/protocol-contracts-solana/pull/102