### PR TITLE
feat: check caller in connected program

### DIFF
--- a/programs/examples/connected/Cargo.toml
+++ b/programs/examples/connected/Cargo.toml
@@ -15,6 +15,7 @@ no-entrypoint = []
 no-idl = []
 no-log-ix-name = []
 idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
+dev = ["gateway/dev"]
 
 [dependencies]
 anchor-lang = { version = "=0.31.1" }

--- a/tests/gateway.ts
+++ b/tests/gateway.ts
@@ -870,6 +870,11 @@ describe("Gateway", () => {
           isSigner: false,
           isWritable: false,
         },
+        {
+          pubkey: anchor.web3.SYSVAR_INSTRUCTIONS_PUBKEY,
+          isSigner: false,
+          isWritable: false,
+        },
       ])
       .rpc();
 
@@ -962,6 +967,11 @@ describe("Gateway", () => {
             isSigner: false,
             isWritable: false,
           },
+          {
+            pubkey: anchor.web3.SYSVAR_INSTRUCTIONS_PUBKEY,
+            isSigner: false,
+            isWritable: false,
+          },
         ])
         .rpc();
       throw new Error("Expected error not thrown"); // This line will make the test fail if no error is thrown
@@ -1032,6 +1042,11 @@ describe("Gateway", () => {
           { pubkey: randomWallet.publicKey, isSigner: false, isWritable: true },
           {
             pubkey: anchor.web3.SystemProgram.programId,
+            isSigner: false,
+            isWritable: false,
+          },
+          {
+            pubkey: anchor.web3.SYSVAR_INSTRUCTIONS_PUBKEY,
             isSigner: false,
             isWritable: false,
           },
@@ -1110,6 +1125,11 @@ describe("Gateway", () => {
             isSigner: false,
             isWritable: false,
           },
+          {
+            pubkey: anchor.web3.SYSVAR_INSTRUCTIONS_PUBKEY,
+            isSigner: false,
+            isWritable: false,
+          },
         ])
         .rpc();
       throw new Error("Expected error not thrown"); // This line will make the test fail if no error is thrown
@@ -1182,6 +1202,11 @@ describe("Gateway", () => {
           { pubkey: randomWallet.publicKey, isSigner: false, isWritable: true },
           {
             pubkey: anchor.web3.SystemProgram.programId,
+            isSigner: false,
+            isWritable: false,
+          },
+          {
+            pubkey: anchor.web3.SYSVAR_INSTRUCTIONS_PUBKEY,
             isSigner: false,
             isWritable: false,
           },


### PR DESCRIPTION
just for illustration how it is possible to check that gateway called connected program, without modifying or signing anything in gateway

same approach can be used for on_revert or connected spl, it is responsibility of connected programs to include this check and users can pass sysvar account in remaining_accounts

therefore https://github.com/zeta-chain/protocol-private/issues/232 appears to not be valid