### PR TITLE
test: add example program using withdraw and call with ALT

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -2,19 +2,13 @@
 anchor_version = "0.31.1"
 solana_version = "2.1.0"
 
-[workspace]
-members = [
-  "programs/gateway",
-  "programs/examples/connected",
-  "programs/examples/connectedSPL"
-]
-
 [features]
 resolution = true
 skip-lint = false
 
 [programs.localnet]
 connected = "4xEw862A2SEwMjofPkUyd4NEekmVJKJsdHkK3UkAtDrc"
+connected_alt = "CKUn75XW5LQFRPZLScBuzdp2JaActxZQX4kZY1B9NryL"
 connected_spl = "8iUjRRhUCn8BjrvsWPfj8mguTe9L81ES4oAUApiF8JFC"
 gateway = "ZETAjseVjuFsxdRxo6MmTCvqFwb3ZHUx56Co3vCmGis"
 
@@ -22,12 +16,15 @@ gateway = "ZETAjseVjuFsxdRxo6MmTCvqFwb3ZHUx56Co3vCmGis"
 url = "https://api.apr.dev"
 
 [provider]
-cluster = "Localnet"
+cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
+[workspace]
+members = ["programs/gateway", "programs/examples/connected", "programs/examples/connectedSPL", "programs/examples/connectedALT"]
+
 [scripts]
-test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
-build-gateway-dev = "anchor build --program-name gateway -- --features dev"
+build-examples = "anchor build --program-name connected && anchor build --program-name connected_spl && anchor build --program-name connected_alt"
 build-gateway = "anchor build --program-name gateway"
+build-gateway-dev = "anchor build --program-name gateway -- --features dev"
 build-gateway-dev-upgrade-test = "anchor build --program-name gateway -- --features dev --features upgrade-test && mv target/deploy/gateway.so target/deploy/gateway_upgrade.so"
-build-examples = "anchor build --program-name connected && anchor build --program-name connected_spl"
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,6 +513,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "connectedALT"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "gateway",
+ "spl-associated-token-account",
+]
+
+[[package]]
 name = "connectedSPL"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,8 @@
 members = [
     "programs/gateway",
     "programs/examples/connected",
-    "programs/examples/connectedSPL"
+    "programs/examples/connectedSPL",
+    "programs/examples/connectedALT"
 ]
 resolver = "2"
 

--- a/programs/examples/connectedALT/Cargo.toml
+++ b/programs/examples/connectedALT/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "connectedALT"
+version = "0.1.0"
+description = "Test program used for testing withdraw and call feature with big number of accounts"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "connected_alt"
+
+[features]
+default = []
+cpi = ["no-entrypoint"]
+no-entrypoint = []
+no-idl = []
+no-log-ix-name = []
+idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
+dev = ["gateway/dev"]
+
+[dependencies]
+anchor-lang = { version = "=0.31.1" }
+anchor-spl = { version = "=0.31.1" }
+spl-associated-token-account = { version = "6.0.0", features = ["no-entrypoint"] }
+gateway = { path = "../../gateway", features = ["no-entrypoint", "cpi"] }

--- a/programs/examples/connectedALT/Xargo.toml
+++ b/programs/examples/connectedALT/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/programs/examples/connectedALT/src/lib.rs
+++ b/programs/examples/connectedALT/src/lib.rs
@@ -1,0 +1,122 @@
+use anchor_lang::prelude::*;
+use anchor_lang::solana_program::{sysvar, sysvar::instructions::get_instruction_relative};
+use std::mem::size_of;
+
+declare_id!("CKUn75XW5LQFRPZLScBuzdp2JaActxZQX4kZY1B9NryL");
+
+
+// NOTE: this is just example contract that can be called from gateway in execute function for testing withdraw and call
+// difference between `connected` and `connected_alt` is that this one requires 85 accounts in `on_call`
+#[program]
+pub mod connected_alt {
+    use super::*;
+
+    pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {
+        Ok(())
+    }
+
+    pub fn on_call(
+        ctx: Context<OnCall>,
+        amount: u64,
+        sender: [u8; 20],
+        data: Vec<u8>,
+    ) -> Result<()> {
+        // Verify that the caller is the gateway program
+        let current_ix = get_instruction_relative(
+            0,
+            &ctx.accounts.instruction_sysvar_account.to_account_info(),
+        )
+        .unwrap();
+
+        msg!(
+            "on_call invoked by: {}, gateway is {}",
+            current_ix.program_id,
+            gateway::ID
+        );
+
+        require!(
+            current_ix.program_id == gateway::ID,
+            ErrorCode::InvalidCaller
+        );
+
+        let pda = &mut ctx.accounts.pda;
+
+        // Store sender and message
+        pda.last_sender = sender;
+        let message = String::from_utf8(data).map_err(|_| ErrorCode::InvalidDataFormat)?;
+        pda.last_message = message;
+
+        // 1st used to get funds and 80 more for ALT demonstration
+        require!(
+            ctx.remaining_accounts.len() == 81,
+            ErrorCode::InvalidRemainingAccounts
+        );
+
+        // Transfer half the amount to the first remaining account
+        let target = &ctx.remaining_accounts[0];
+        pda.sub_lamports(amount / 2)?;
+        target.add_lamports(amount / 2)?;
+
+        // Optional: revert on "revert" message
+        if pda.last_message.contains("revert") {
+            msg!("Reverting due to message: {}", pda.last_message);
+            return Err(ErrorCode::RevertMessage.into());
+        }
+
+        msg!(
+            "On call executed with amount {}, sender {:?} and message {}",
+            amount,
+            pda.last_sender,
+            pda.last_message
+        );
+
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct Initialize<'info> {
+    #[account(mut)]
+    pub signer: Signer<'info>,
+
+    #[account(init, payer = signer, space = size_of::<Pda>() + 32, seeds = [b"connected"], bump)]
+    pub pda: Account<'info, Pda>,
+
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct OnCall<'info> {
+    #[account(mut, seeds = [b"connected"], bump)]
+    pub pda: Account<'info, Pda>,
+
+    /// CHECK: gateway PDA
+    pub gateway_pda: UncheckedAccount<'info>,
+
+    pub system_program: Program<'info, System>,
+
+    /// CHECK: sysvar instructions
+    #[account(address = sysvar::instructions::id())]
+    pub instruction_sysvar_account: UncheckedAccount<'info>,
+}
+
+#[account]
+pub struct Pda {
+    pub last_sender: [u8; 20],
+    pub last_message: String,
+}
+
+#[error_code]
+pub enum ErrorCode {
+    #[msg("Invalid UTF-8 data format.")]
+    InvalidDataFormat,
+
+    #[msg("Revert message detected.")]
+    RevertMessage,
+
+    #[msg("Caller is not the gateway program.")]
+    InvalidCaller,
+
+    #[msg("Missing required remaining accounts.")]
+    InvalidRemainingAccounts,
+}


### PR DESCRIPTION
Adds one more connected example, with large number of accounts, probably same connected program can be used, but this way there can be revert in case not exact number of accounts is provided.

It seems with this simplest example 85 accounts is the most, this is compute unit limit because there is some logic in gateway, if connected program logic is more complex, but without using ALT it is less than 30 remaining accounts possible, as demonstrated in test as well.