### PR TITLE
feat: improve withdraw spl conditions when ata doesnt exist

### DIFF
--- a/programs/gateway/src/errors.rs
+++ b/programs/gateway/src/errors.rs
@@ -23,4 +23,6 @@ pub enum Errors {
     EmptyReceiver,
     #[msg("InvalidInstructionData")]
     InvalidInstructionData,
+    #[msg("InvalidAtaOwner")]
+    InvalidAtaOwner,
 }

--- a/programs/gateway/src/instructions/withdraw.rs
+++ b/programs/gateway/src/instructions/withdraw.rs
@@ -1,12 +1,13 @@
 use crate::{
     contexts::{Withdraw, WithdrawSPLToken},
+    errors::Errors,
     state::InstructionId,
     utils::{validate_message, verify_ata_match, DEFAULT_GAS_COST},
 };
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program::program::invoke;
 use anchor_spl::token::transfer_checked;
-use spl_associated_token_account::instruction::create_associated_token_account;
+use spl_associated_token_account::instruction::create_associated_token_account_idempotent;
 
 // Withdraws SOL. Caller is TSS.
 pub fn handle_sol(
@@ -86,13 +87,19 @@ pub fn handle_spl(
         &ctx.accounts.recipient_ata.key(),
     )?;
 
+    // Check if account is either empty owned by system program or owner is token program
+    let recipient_ata_account = ctx.accounts.recipient_ata.to_account_info();
+    require!(
+        *recipient_ata_account.owner == anchor_spl::token::ID
+            || (*recipient_ata_account.owner == anchor_lang::system_program::ID
+                && recipient_ata_account.lamports() == 0),
+        Errors::InvalidAtaOwner
+    );
+
     // 3. Create recipient ATA if needed and calculate costs
     let mut cost_ata_create: u64 = 0;
-    let recipient_ata_account = ctx.accounts.recipient_ata.to_account_info();
 
-    if recipient_ata_account.lamports() == 0
-        || *recipient_ata_account.owner == ctx.accounts.system_program.key()
-    {
+    if recipient_ata_account.lamports() == 0 {
         // ATA needs to be created
         msg!(
             "Creating associated token account {:?} for recipient {:?}...",
@@ -102,7 +109,7 @@ pub fn handle_spl(
 
         let bal_before = ctx.accounts.signer.lamports();
         invoke(
-            &create_associated_token_account(
+            &create_associated_token_account_idempotent(
                 ctx.accounts.signer.to_account_info().key,
                 ctx.accounts.recipient.to_account_info().key,
                 ctx.accounts.mint_account.to_account_info().key,

--- a/programs/gateway/src/instructions/withdraw.rs
+++ b/programs/gateway/src/instructions/withdraw.rs
@@ -7,7 +7,7 @@ use crate::{
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program::program::invoke;
 use anchor_spl::token::transfer_checked;
-use spl_associated_token_account::instruction::create_associated_token_account_idempotent;
+use spl_associated_token_account::instruction::create_associated_token_account;
 
 // Withdraws SOL. Caller is TSS.
 pub fn handle_sol(
@@ -109,7 +109,7 @@ pub fn handle_spl(
 
         let bal_before = ctx.accounts.signer.lamports();
         invoke(
-            &create_associated_token_account_idempotent(
+            &create_associated_token_account(
                 ctx.accounts.signer.to_account_info().key,
                 ctx.accounts.recipient.to_account_info().key,
                 ctx.accounts.mint_account.to_account_info().key,

--- a/tests/gateway.ts
+++ b/tests/gateway.ts
@@ -3361,6 +3361,54 @@ describe("Gateway", () => {
     expect(rentPayerPdaBal0 - rentPayerPdaBal1).to.be.eq(to_ata_bal + 5000); // rentPayer pays rent
   });
 
+  it("Withdrawal when a system account exists at the ATA address fails", async () => {
+    // new ata
+    const recipient = anchor.web3.Keypair.generate();
+    const maliciousAta = await spl.getAssociatedTokenAddress(
+      mint.publicKey,
+      recipient.publicKey,
+      false
+    );
+
+    // create system owned account using ata address
+    const lamports = await conn.getMinimumBalanceForRentExemption(8);
+    const maliciousTx = new anchor.web3.Transaction().add(
+      anchor.web3.SystemProgram.transfer({
+        fromPubkey: wallet.publicKey,
+        toPubkey: maliciousAta,
+        lamports,
+      })
+    );
+    await anchor.web3.sendAndConfirmTransaction(conn, maliciousTx, [wallet]);
+
+    // atempt withdrawal — should fail
+    const pdaAta = await spl.getAssociatedTokenAddress(
+      mint.publicKey,
+      pdaAccount,
+      true
+    );
+    const pdaAccountData = await gatewayProgram.account.pda.fetch(pdaAccount);
+    const amount = new anchor.BN(500_000);
+    const nonce = pdaAccountData.nonce;
+
+    try {
+      await withdrawSplToken(
+        mint,
+        usdcDecimals,
+        amount,
+        nonce,
+        pdaAta,
+        maliciousAta,
+        recipient.publicKey,
+        gatewayProgram
+      );
+      throw new Error("Expected error not thrown");
+    } catch (err) {
+      expect(err).to.be.instanceof(anchor.AnchorError);
+      expect(err.message).to.include("InvalidAtaOwner");
+    }
+  });
+
   it("Withdraw SPL token with wrong nonce should fail", async () => {
     let pda_ata = await spl.getAssociatedTokenAddress(
       mint.publicKey,

--- a/tests/gateway.ts
+++ b/tests/gateway.ts
@@ -3381,7 +3381,7 @@ describe("Gateway", () => {
     );
     await anchor.web3.sendAndConfirmTransaction(conn, maliciousTx, [wallet]);
 
-    // atempt withdrawal — should fail
+    // attempt withdrawal — should fail
     const pdaAta = await spl.getAssociatedTokenAddress(
       mint.publicKey,
       pdaAccount,


### PR DESCRIPTION
https://github.com/zeta-chain/protocol-private/issues/348

hardening condition a bit, check if ata is either owned by token program id or owned by system program and no lamports

before it was trying to create ata either if its 0 lamports or owned by system program, but it can happen that system program owned account that already exists was passed

this to me seems like a nice to have, i tested and in this case owner is still set correctly to token program id after create is called, but probably a good check to have
