### PR TITLE
feat: enable native token refund

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -15,17 +15,22 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@1.88.0
 
-      - name: Install Node.js, Solana CLI, and Anchor
-        uses: heyAyushh/setup-anchor@v4.93
-        with:
-          use-avm: true
-          solana-cli-version: "2.1.0"
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libudev-dev pkg-config libssl-dev
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "22.14.0"
           registry-url: "https://registry.npmjs.org"
+
+      - name: Setup Solana
+        uses: heyAyushh/setup-solana@v5.9
+        with:
+          solana-cli-version: "2.1.0"
+
+      - name: Install Anchor CLI
+        run: cargo install --git https://github.com/coral-xyz/anchor --tag v0.31.1 anchor-cli --locked --force
 
       - name: Build Prod
         run: |

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -13,12 +13,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.88.0
 
       - name: Install Node.js, Solana CLI, and Anchor
         uses: heyAyushh/setup-anchor@v4.93
         with:
           use-avm: true
+          solana-cli-version: "2.1.0"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,11 +14,21 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@1.88.0
 
-      - name: Setup Anchor
-        uses: heyAyushh/setup-anchor@v4.93
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libudev-dev pkg-config libssl-dev
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          use-avm: true
+          node-version: "22.14.0"
+
+      - name: Setup Solana
+        uses: heyAyushh/setup-solana@v5.9
+        with:
           solana-cli-version: "2.1.0"
+
+      - name: Install Anchor CLI
+        run: cargo install --git https://github.com/coral-xyz/anchor --tag v0.31.1 anchor-cli --locked --force
 
       - name: Display Versions
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@1.88.0
+
       - name: Setup Anchor
         uses: heyAyushh/setup-anchor@v4.93
         with:
           use-avm: true
+          solana-cli-version: "2.1.0"
 
       - name: Display Versions
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,12 @@ members = [
 ]
 resolver = "2"
 
+[workspace.lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(feature, values("anchor-debug", "custom-heap", "custom-panic"))',
+    'cfg(target_os, values("solana"))',
+] }
+
 [profile.release]
 overflow-checks = true
 lto = "fat"

--- a/programs/examples/connected/Cargo.toml
+++ b/programs/examples/connected/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 description = "Test program used for testing withdraw and call feature"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [lib]
 crate-type = ["cdylib", "lib"]
 name = "connected"
@@ -20,5 +23,7 @@ dev = ["gateway/dev"]
 [dependencies]
 anchor-lang = { version = "=0.31.1" }
 anchor-spl = { version = "=0.31.1" }
-spl-associated-token-account = { version = "6.0.0", features = ["no-entrypoint"] }
+spl-associated-token-account = { version = "6.0.0", features = [
+    "no-entrypoint",
+] }
 gateway = { path = "../../gateway", features = ["no-entrypoint", "cpi"] }

--- a/programs/examples/connectedSPL/Cargo.toml
+++ b/programs/examples/connectedSPL/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 description = "Test program used for testing withdraw and call SPL feature"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [lib]
 crate-type = ["cdylib", "lib"]
 name = "connected_spl"
@@ -19,4 +22,6 @@ idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
 [dependencies]
 anchor-lang = { version = "=0.31.1" }
 anchor-spl = { version = "=0.31.1" }
-spl-associated-token-account = { version = "6.0.0", features = ["no-entrypoint"] }
+spl-associated-token-account = { version = "6.0.0", features = [
+    "no-entrypoint",
+] }

--- a/programs/gateway/Cargo.toml
+++ b/programs/gateway/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 description = "ZetaChain Gateway program on Solana"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [lib]
 crate-type = ["cdylib", "lib"]
 name = "gateway"
@@ -21,4 +24,6 @@ dev = []
 [dependencies]
 anchor-lang = { version = "=0.31.1" }
 anchor-spl = { version = "=0.31.1" }
-spl-associated-token-account = { version = "6.0.0", features = ["no-entrypoint"] }
+spl-associated-token-account = { version = "6.0.0", features = [
+    "no-entrypoint",
+] }

--- a/programs/gateway/src/contexts.rs
+++ b/programs/gateway/src/contexts.rs
@@ -313,6 +313,23 @@ pub struct Unwhitelist<'info> {
     pub whitelist_candidate: Account<'info, Mint>,
 }
 
+/// Instruction context for refunding native SOL from gateway custody.
+#[derive(Accounts)]
+pub struct RefundSol<'info> {
+    /// The authority account refunding SOL from custody.
+    #[account(mut)]
+    pub signer: Signer<'info>,
+
+    /// Gateway PDA.
+    #[account(mut, seeds = [b"meta"], bump)]
+    pub pda: Account<'info, Pda>,
+
+    /// The recipient wallet receiving the refunded SOL.
+    /// CHECK: Recipient account is not read; ownership validation is unnecessary.
+    #[account(mut)]
+    pub recipient: UncheckedAccount<'info>,
+}
+
 /// Instruction context for refunding SPL tokens from gateway custody.
 #[derive(Accounts)]
 pub struct RefundSplToken<'info> {

--- a/programs/gateway/src/instructions/refund.rs
+++ b/programs/gateway/src/instructions/refund.rs
@@ -1,6 +1,7 @@
 use crate::{
-    contexts::RefundSplToken,
+    contexts::{RefundSol, RefundSplToken},
     errors::Errors,
+    state::Pda,
     utils::{verify_ata_match, verify_authority},
 };
 use anchor_lang::prelude::*;
@@ -8,12 +9,43 @@ use anchor_lang::solana_program::program::invoke;
 use anchor_spl::token::transfer_checked;
 use spl_associated_token_account::instruction::create_associated_token_account;
 
+fn validate_refund_request(authority: &Pubkey, pda: &Account<Pda>, amount: u64) -> Result<()> {
+    verify_authority(authority, pda)?;
+    require!(amount > 0, Errors::InvalidAmount);
+    Ok(())
+}
+
+// Refunds native SOL from gateway custody to a user. Caller is authority stored in PDA.
+pub fn handle_sol(ctx: Context<RefundSol>, amount: u64) -> Result<()> {
+    let pda = &ctx.accounts.pda;
+
+    validate_refund_request(&ctx.accounts.signer.key(), pda, amount)?;
+
+    let pda_info = pda.to_account_info();
+    let rent = Rent::get()?;
+    let min_balance = rent.minimum_balance(pda_info.data_len());
+    let available = pda_info.lamports().saturating_sub(min_balance);
+
+    require!(available >= amount, Errors::InsufficientBalance);
+
+    pda_info.sub_lamports(amount)?;
+    ctx.accounts.recipient.add_lamports(amount)?;
+
+    msg!(
+        "Refund SOL executed: amount = {}, recipient = {}, authority = {}",
+        amount,
+        ctx.accounts.recipient.key(),
+        ctx.accounts.signer.key()
+    );
+
+    Ok(())
+}
+
 // Refunds SPL tokens from gateway custody to a user. Caller is authority stored in PDA.
 pub fn handle_spl(ctx: Context<RefundSplToken>, amount: u64, decimals: u8) -> Result<()> {
     let pda = &ctx.accounts.pda;
 
-    verify_authority(&ctx.accounts.signer.key(), pda)?;
-    require!(amount > 0, Errors::InvalidAmount);
+    validate_refund_request(&ctx.accounts.signer.key(), pda, amount)?;
 
     verify_ata_match(
         &pda.key(),

--- a/programs/gateway/src/lib.rs
+++ b/programs/gateway/src/lib.rs
@@ -380,6 +380,14 @@ pub mod gateway {
         instructions::withdraw::handle_sol(ctx, amount, signature, recovery_id, message_hash, nonce)
     }
 
+    /// Refunds native SOL from gateway custody to a user. Caller is authority stored in PDA.
+    /// # Arguments
+    /// * `ctx` - The instruction context.
+    /// * `amount` - The amount of lamports to refund.
+    pub fn refund_sol(ctx: Context<RefundSol>, amount: u64) -> Result<()> {
+        instructions::refund::handle_sol(ctx, amount)
+    }
+
     /// Refunds SPL tokens from gateway custody to a user. Caller is authority stored in PDA.
     /// # Arguments
     /// * `ctx` - The instruction context.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.83.0"
+channel = "1.88.0"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]

--- a/tests/gateway.ts
+++ b/tests/gateway.ts
@@ -161,6 +161,29 @@ async function withdrawSplToken(
     .rpc({ commitment: "processed" });
 }
 
+async function refundSol(
+  gatewayProgram: Program<Gateway>,
+  amount: anchor.BN,
+  recipient: anchor.web3.PublicKey,
+  signer: anchor.web3.Keypair = anchor.workspace.Gateway.provider.wallet
+    .payer
+) {
+  const [pdaAccount] = anchor.web3.PublicKey.findProgramAddressSync(
+    [Buffer.from("meta", "utf-8")],
+    gatewayProgram.programId
+  );
+
+  return gatewayProgram.methods
+    .refundSol(amount)
+    .accounts({
+      signer: signer.publicKey,
+      pda: pdaAccount,
+      recipient,
+    })
+    .signers(signer.publicKey.equals(anchor.workspace.Gateway.provider.wallet.publicKey) ? [] : [signer])
+    .rpc({ commitment: "processed" });
+}
+
 async function refundSplToken(
   gatewayProgram: Program<Gateway>,
   mint: anchor.web3.PublicKey,
@@ -3942,6 +3965,102 @@ describe("Gateway", () => {
     } catch (err) {
       expect(err).to.be.instanceof(anchor.AnchorError);
       expect(err.message).to.include("NonceMismatch.");
+    }
+  });
+
+  it("Refund SOL to user", async () => {
+    const refundAmount = new anchor.BN(100_000_000);
+    const refundRecipient = anchor.web3.Keypair.generate();
+    const pdaBalanceBefore = await conn.getBalance(pdaAccount);
+    const recipientBalanceBefore = await conn.getBalance(
+      refundRecipient.publicKey
+    );
+
+    await refundSol(
+      gatewayProgram,
+      refundAmount,
+      refundRecipient.publicKey
+    );
+
+    const pdaBalanceAfter = await conn.getBalance(pdaAccount);
+    const recipientBalanceAfter = await conn.getBalance(
+      refundRecipient.publicKey
+    );
+    expect(pdaBalanceBefore - pdaBalanceAfter).to.equal(
+      refundAmount.toNumber()
+    );
+    expect(recipientBalanceAfter - recipientBalanceBefore).to.equal(
+      refundAmount.toNumber()
+    );
+  });
+
+  it("Refund SOL fails for non-authority", async () => {
+    try {
+      await refundSol(
+        gatewayProgram,
+        new anchor.BN(1),
+        wallet.publicKey,
+        random_account
+      );
+      throw new Error("Expected error not thrown");
+    } catch (err) {
+      expect(err).to.be.instanceof(anchor.AnchorError);
+      expect(err.message).to.include("SignerIsNotAuthority");
+    }
+  });
+
+  it("Refund SOL fails for insufficient balance", async () => {
+    const pdaAccountInfo = await conn.getAccountInfo(pdaAccount);
+    const rentExempt = await conn.getMinimumBalanceForRentExemption(
+      pdaAccountInfo!.data.length
+    );
+    const pdaBalance = await conn.getBalance(pdaAccount);
+    const maxRefund = pdaBalance - rentExempt;
+
+    try {
+      await refundSol(
+        gatewayProgram,
+        new anchor.BN(maxRefund + 1),
+        wallet.publicKey
+      );
+      throw new Error("Expected error not thrown");
+    } catch (err) {
+      expect(err).to.be.instanceof(anchor.AnchorError);
+      expect(err.message).to.include("InsufficientBalance");
+    }
+  });
+
+  it("Refund SOL fails for zero amount", async () => {
+    try {
+      await refundSol(
+        gatewayProgram,
+        new anchor.BN(0),
+        wallet.publicKey
+      );
+      throw new Error("Expected error not thrown");
+    } catch (err) {
+      expect(err).to.be.instanceof(anchor.AnchorError);
+      expect(err.message).to.include("InvalidAmount");
+    }
+  });
+
+  it("Refund SOL works while deposits are paused", async () => {
+    await gatewayProgram.methods.setDepositPaused(true).rpc();
+
+    try {
+      const refundRecipient = anchor.web3.Keypair.generate();
+      const refundAmount = new anchor.BN(50_000_000);
+
+      await refundSol(
+        gatewayProgram,
+        refundAmount,
+        refundRecipient.publicKey
+      );
+
+      const recipientBalance = await conn.getBalance(refundRecipient.publicKey);
+      expect(recipientBalance).to.equal(refundAmount.toNumber());
+    } finally {
+      await gatewayProgram.methods.setDepositPaused(false).rpc();
     }
   });
 


### PR DESCRIPTION
Add logic for native SOL refund.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moves real SOL from the gateway PDA without TSS signatures; controls match SPL refunds but custody outflows warrant careful operational review.
> 
> **Overview**
> Adds **`refund_sol`**, mirroring the existing SPL refund path: only the PDA **authority** can move lamports from the gateway meta PDA to any recipient wallet.
> 
> The handler shares **`validate_refund_request`** with SPL refunds (authority + positive amount), caps refunds to lamports above rent-exempt minimum on the PDA, and transfers via direct lamport debit/credit. Deposits can stay paused; refunds are not blocked by **`set_deposit_paused`**.
> 
> Anchor tests cover happy path, non-authority, insufficient balance, zero amount, and refund while deposits are paused.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb04a9cd2307cd393e9853d25991fc5681656b6e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->